### PR TITLE
chore(types): cleanup

### DIFF
--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -104,42 +104,43 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     extendTypes('nuxt-site-config', async ({ typesPath }) => {
-      return `
+      return `import type { SiteConfig, SiteConfigInput, SiteConfigStack } from '${typesPath}'
+
 declare module 'nitropack' {
   interface NitroRouteRules {
-    site?: import('${typesPath}').SiteConfigInput
+    site?: SiteConfigInput
   }
   interface NitroRouteConfig {
-    site?: import('${typesPath}').SiteConfig
+    site?: SiteConfig
   }
 }
 
 declare module 'h3' {
   interface H3EventContext {
-    siteConfig: import('${typesPath}').SiteConfigStack
+    siteConfig: SiteConfigStack
   }
 }
 
 declare module 'nuxt/schema' {
   interface AppConfigInput {
     /** Theme configuration */
-    site?: import('${typesPath}').SiteConfigInput
+    site?: SiteConfigInput
   }
 }
 
 declare module '@nuxt/schema' {
   interface AppConfigInput {
     /** Theme configuration */
-    site?: import('${typesPath}').SiteConfigInput
+    site?: SiteConfigInput
   }
   interface Nuxt {
-    _siteConfig?: import('${typesPath}').SiteConfigStack
+    _siteConfig?: SiteConfigStack
   }
 }
 
 declare module '@nuxt/schema' {
   export interface RuntimeNuxtHooks {
-    'site-config:resolve': (siteConfig: import('${typesPath}').SiteConfig) => void
+    'site-config:resolve': (siteConfig: SiteConfig) => void
   }
 }
 `

--- a/packages/module/src/runtime/composables/updateSiteConfig.ts
+++ b/packages/module/src/runtime/composables/updateSiteConfig.ts
@@ -1,6 +1,5 @@
 import type {
   SiteConfigInput,
-  SiteConfigStack,
 } from 'site-config-stack'
 import { useNuxtApp, useRequestEvent } from '#imports'
 
@@ -11,6 +10,6 @@ export function updateSiteConfig(input: SiteConfigInput = {}) {
     return
   }
 
-  const stack = useNuxtApp().$siteConfig as SiteConfigStack
+  const stack = useNuxtApp().$siteConfig
   stack.push(input)
 }


### PR DESCRIPTION
### Description

Just some opportunities to cleanup types that I came across while preparing my next PR.

### Linked Issues

n/a

### Additional context

Any reason for the repeated `typesPath` usage?
