### PR TITLE
feat!: implement singleton

### DIFF
--- a/packages/module/src/runtime/nitro/composables/useSiteConfig.ts
+++ b/packages/module/src/runtime/nitro/composables/useSiteConfig.ts
@@ -1,8 +1,16 @@
 import type { H3Event } from 'h3'
+import type { SiteConfigInput } from 'site-config-stack'
 import { createSiteConfigStack } from 'site-config-stack'
 import type { NuxtSiteConfig } from '../../types'
 
 export function useSiteConfig(e: H3Event) {
   e.context.siteConfig = e.context.siteConfig || createSiteConfigStack()
-  return e.context.siteConfig.get() as NuxtSiteConfig
+  return {
+    get value(): NuxtSiteConfig {
+      return e.context.siteConfig.get() as NuxtSiteConfig
+    },
+    set value(value: SiteConfigInput) {
+      e.context.siteConfig.push(value)
+    },
+  }
 }

--- a/playground/server/api/composables.ts
+++ b/playground/server/api/composables.ts
@@ -3,15 +3,15 @@ import { useSiteConfig, updateSiteConfig, eventHandler } from '#imports'
 export default eventHandler(e => {
   debugger
   const siteConfigStart = useSiteConfig(e)
-  const descriptionStart = siteConfigStart.description
+  const descriptionStart = siteConfigStart.value.description
 
   updateSiteConfig(e, {
     description: 'Description'
   })
 
-  const descriptionStartAfterChange = siteConfigStart.description
+  const descriptionStartAfterChange = siteConfigStart.value.description
   const siteConfigEnd = useSiteConfig(e)
-  const descriptionEnd = siteConfigEnd.description
+  const descriptionEnd = siteConfigEnd.value.description
 
   return [descriptionStart, descriptionStartAfterChange, descriptionEnd]
 })

--- a/playground/server/api/composables.ts
+++ b/playground/server/api/composables.ts
@@ -1,0 +1,17 @@
+import { useSiteConfig, updateSiteConfig, eventHandler } from '#imports'
+
+export default eventHandler(e => {
+  debugger
+  const siteConfigStart = useSiteConfig(e)
+  const descriptionStart = siteConfigStart.description
+
+  updateSiteConfig(e, {
+    description: 'Description'
+  })
+
+  const descriptionStartAfterChange = siteConfigStart.description
+  const siteConfigEnd = useSiteConfig(e)
+  const descriptionEnd = siteConfigEnd.description
+
+  return [descriptionStart, descriptionStartAfterChange, descriptionEnd]
+})

--- a/playground/server/api/default.ts
+++ b/playground/server/api/default.ts
@@ -3,6 +3,6 @@ import { useSiteConfig, useNitroOrigin, eventHandler } from '#imports'
 export default eventHandler(e => {
   return {
     origin: useNitroOrigin(e),
-    ...useSiteConfig(e)
+    ...useSiteConfig(e).value
   }
 })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -34,4 +34,16 @@ describe('basic', async () => {
       }
     `)
   })
+
+  it ('updates site configuration', async () => {
+    const siteConfig = await $fetch('/api/composables')
+    const s = JSON.stringify(siteConfig)
+    expect(JSON.parse(s.replace(/:\d+\//g, ':port/'))).toMatchInlineSnapshot(`
+      [
+        null,
+        "Description",
+        "Description",
+      ]
+    `)
+  })
 })


### PR DESCRIPTION
### Description

BREAKING: `useSiteConfig` now has a `value` getter & setter which allows to use it anytime and access up-to-date variables inside.

### Linked Issues

n/a

### Additional context

See [the test](https://github.com/harlan-zw/nuxt-site-config/commit/5c192692fda59f7b8c2ae888218cd62f7a2c66f3#diff-50c9bc28675a5a77fd7ea97ad64e03e9466a657cad0459a10048f1859c0850b5) as an example for what's currently failing: using `site-config`, then updating it and checking for updates values through the `site-config` used before.