### PR TITLE
fix(site-link): use nuxt's link properties

### DIFF
--- a/packages/module/src/runtime/nuxt/component/SiteLink.vue
+++ b/packages/module/src/runtime/nuxt/component/SiteLink.vue
@@ -1,11 +1,8 @@
 <script lang="ts" setup>
 import { computed, toRefs } from 'vue'
-import type { defineNuxtLink } from 'nuxt/app'
+import type { NuxtLinkProps } from 'nuxt/app'
 import type { CreateSitePathResolverOptions } from '../../types'
 import { createSitePathResolver, resolveComponent } from '#imports'
-
-// get first argument type
-type NuxtLinkProps = Parameters<typeof defineNuxtLink>[0]
 
 const props = defineProps<CreateSitePathResolverOptions & NuxtLinkProps>()
 


### PR DESCRIPTION
### Description

This could fix the type issue on the `SiteLink` component.

### Linked Issues

https://github.com/harlan-zw/nuxt-site-config/issues/17

### Additional context

I'm not sure why `NuxtLinkOptions` is currently in use, as I'd expect `NuxtLinkProps`. If options are used as intended after all, feel free to close this PR.
