### PR TITLE
 fix: do not augment nuxt/schema

### DIFF
--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -113,16 +113,6 @@ declare module 'h3' {
   }
 }
 
-declare module 'nuxt/schema' {
-  interface AppConfigInput {
-    /** Theme configuration */
-    site?: import('${typesPath}').SiteConfigInput
-  }
-  interface Nuxt {
-    _siteConfig?: import('${typesPath}').SiteConfigStack
-  }
-}
-
 declare module '@nuxt/schema' {
   interface AppConfigInput {
     /** Theme configuration */


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Context: nuxt/nuxt#28332

`nuxt/schema` is a re-export of `@nuxt/schema` for users to use. Modules should not augment it, or it may end up overwriting the inferred types from `@nuxt/schema`.

### Linked Issues

nuxt/nuxt#28332

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
