### PR TITLE
docs: fix using incorrect component name

### DIFF
--- a/docs/content/4.api/0.site-link.md
+++ b/docs/content/4.api/0.site-link.md
@@ -62,8 +62,8 @@ export default defineNuxtConfig({
 
 ```vue
 <template>
-  <ISiteConfig to="/foo">
+  <ISiteLink to="/foo">
     Foo
-  </ISiteConfig>
+  </ISiteLink>
 </template>
 ```

--- a/docs/content/4.api/config.md
+++ b/docs/content/4.api/config.md
@@ -37,9 +37,9 @@ export default defineNuxtConfig({
 
 ```vue
 <template>
-  <ISiteConfig to="/foo">
+  <ISiteLink to="/foo">
     Foo
-  </ISiteConfig>
+  </ISiteLink>
 </template>
 ```
 


### PR DESCRIPTION
### Description

This PR fixes the incorrect usage of `SiteLink` in a couple places on the docs.

### Linked Issues

None.

### Additional context

From looking at the code, I believe there is no way to name it that way so it is probably a copy+paste related issue.

https://github.com/harlan-zw/nuxt-site-config/blob/5667261e2915790bf5ffc52cde9296869c7cf7cd/packages/module/src/module.ts#L160