### PR TITLE
fix(i18n): continue on warning

### DIFF
--- a/packages/module/src/runtime/app/plugins/i18n.server.ts
+++ b/packages/module/src/runtime/app/plugins/i18n.server.ts
@@ -20,10 +20,11 @@ export default defineNuxtPlugin({
       if (import.meta.dev && url.host) {
         if (url.host.includes('localhost'))
           console.warn(`[Nuxt Site Config] You have set an i18n baseUrl to \`${url.host}\`. This will not work in production. Please set a proper baseUrl in your i18n config.`)
-        else if (!currentUrl.includes(url.host))
+
+        if (!currentUrl.includes(url.host))
           console.warn(`[Nuxt Site Config] Your i18n baseUrl \`${url}\` doesn't match your site url. This can lead to unexpected behavior. Please set a matching baseUrl in your i18n config.`)
-        else
-          i18nBaseUrl = url.host
+
+        i18nBaseUrl = url.host
       }
     }
     catch {}


### PR DESCRIPTION
### Description

Right now the warnings don't just point out a potential issue and continue as usual, but prevent the `i18n` base URL to be set. I think that the warnings should either be an error so that one is more likely to guess an influence on behavior or the warnings should not influence the behavior. This implements the latter option.

### Linked Issues

n/a

### Additional context

I'm dynamically settings the base URL to be some `localhost` address in development and a proper address in production, sourced form an environment variable provided by the CI environment. This way I can be flexible to deploy multiple static builds under different base URLs. I wonder if this is a valid strategy or if there is a better way in your opinion, @harlan-zw. If it's valid, then I'd like to be able to mute the warning about `localhost` usage in development or instead have an error when building for production and `localhost` is still set as base URL. What do you think?