### PR TITLE
feat: `multiTenancy` build-time config

### DIFF
--- a/docs/content/2.guides/multi-tenancy.md
+++ b/docs/content/2.guides/multi-tenancy.md
@@ -43,11 +43,11 @@ export default defineNuxtConfig({
 })
 ```
 
-Each multi-tenant configuration requires:  
+Each multi-tenant configuration requires:
 
 - `hosts`: An array of hostnames that should use this configuration
 
-It's recommended to add any non-canonical hostnames to the `hosts` array to avoid duplicate content issues. For example, 
+It's recommended to add any non-canonical hostnames to the `hosts` array to avoid duplicate content issues. For example,
 www.* and non-www.* hostnames should use the same configuration.
 
 - `config`: The site configuration to apply when the hostname matches

--- a/docs/content/2.guides/multi-tenancy.md
+++ b/docs/content/2.guides/multi-tenancy.md
@@ -3,7 +3,7 @@ title: Multi-Tenancy
 description: Learn how to serve multiple sites with different configurations based on the hostname.
 ---
 
-# Introduction
+## Introduction
 
 Multi-tenancy allows you to serve multiple sites with different configurations using a single Nuxt application. This is useful when you need to:
 - Host multiple domains with different branding
@@ -16,7 +16,7 @@ You can configure multi-tenancy using static configuration or dynamically at run
 
 To use build-time multi-tenancy configuration you can use the `multiTenancy` option:
 
-```ts{3-23}
+```ts
 export default defineNuxtConfig({
   site: {
     multiTenancy: [
@@ -24,17 +24,14 @@ export default defineNuxtConfig({
         hosts: ['www.example.com', 'example.com', 'local.example.com'],
         config: {
           name: 'Example',
-          description: 'Example description',
-          url: 'example.com',
-          defaultLocale: 'en',
-          currentLocale: 'en',
+          url: 'example.com' // canonical
         },
       },
       {
         hosts: ['www.foo.com', 'foo.com', 'local.foo.com'],
         config: {
-          url: 'foo.com',
           name: 'Foo',
+          url: 'foo.com', // canonical
           description: 'Foo description',
         },
       },

--- a/docs/content/2.guides/multi-tenancy.md
+++ b/docs/content/2.guides/multi-tenancy.md
@@ -1,0 +1,92 @@
+---
+title: Multi-Tenancy
+description: Learn how to serve multiple sites with different configurations based on the hostname.
+---
+
+# Introduction
+
+Multi-tenancy allows you to serve multiple sites with different configurations using a single Nuxt application. This is useful when you need to:
+- Host multiple domains with different branding
+- Serve region-specific content
+- Maintain multiple sites with shared codebase
+
+You can configure multi-tenancy using static configuration or dynamically at runtime.
+
+## Usage
+
+To use build-time multi-tenancy configuration you can use the `multiTenancy` option:
+
+```ts{3-23}
+export default defineNuxtConfig({
+  site: {
+    multiTenancy: [
+      {
+        hosts: ['www.example.com', 'example.com', 'local.example.com'],
+        config: {
+          name: 'Example',
+          description: 'Example description',
+          url: 'example.com',
+          defaultLocale: 'en',
+          currentLocale: 'en',
+        },
+      },
+      {
+        hosts: ['www.foo.com', 'foo.com', 'local.foo.com'],
+        config: {
+          url: 'foo.com',
+          name: 'Foo',
+          description: 'Foo description',
+        },
+      },
+    ]
+  }
+})
+```
+
+Each multi-tenant configuration requires:  
+
+- `hosts`: An array of hostnames that should use this configuration
+
+It's recommended to add any non-canonical hostnames to the `hosts` array to avoid duplicate content issues. For example, 
+www.* and non-www.* hostnames should use the same configuration.
+
+- `config`: The site configuration to apply when the hostname matches
+
+The config object supports all standard site configuration options plus any custom properties you need.
+
+## How it works
+
+1. When a request is received, the module checks the hostname against the configured hosts arrays
+2. If a match is found, the corresponding config is applied
+3. The configuration is made available through the `useSiteConfig()` composable
+
+## Runtime Multi-Tenancy
+
+Runtime multi-tenancy is useful when you need to:
+
+- Set configuration based on complex runtime conditions
+- Load configuration from external sources
+- Handle dynamic subdomains
+- Implement A/B testing scenarios
+
+To use get started with runtime multi-tenancy you'll need to create a Nitro plugin.
+
+```ts [server/plugins/site-config.ts]
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('site-config:init', ({ event, siteConfig }) => {
+    const origin = useNitroOrigin(event)
+    // Example: Set configuration based on subdomain
+    if (origin.startsWith('fr.')) {
+      // push whatever config you'd like for this request
+      siteConfig.push({
+        name: 'Mon Site',
+        url: 'https://fr.example.com',
+        defaultLocale: 'fr',
+        currentLocale: 'fr',
+      })
+    }
+  })
+})
+```
+
+Check the [`site-config:init`](/docs/site-config/nitro-api/nitro-hooks#site-config-init) hook documentation for more information.

--- a/docs/content/4.api/config.md
+++ b/docs/content/4.api/config.md
@@ -1,4 +1,4 @@
----
+_---
 title: Nuxt Config
 description: The config options available for Nuxt Site Config.
 ---
@@ -16,6 +16,43 @@ Whether the site config is enabled.
 - Default: `false`
 
 Whether the debug mode of the site config is enabled.
+
+## `multiTenancy`
+
+- Type: `{ hosts: string[]; config: SiteConfigInput }[]`{lang="ts"}
+- Default: `[]`{lang="ts"}
+
+Configure multiple sites with different configurations based on the host. Each site configuration requires:
+
+- `hosts`: An array of hostnames that should use this configuration
+- `config`: The site configuration to use when the hostname matches
+
+```ts [Example]
+export default defineNuxtConfig({
+  site: {
+    multiTenancy: [
+      {
+        hosts: ['www.example.com', 'example.com', 'local.example.com'],
+        config: {
+          name: 'Example',
+          description: 'Example description',
+          url: 'example.com',
+          defaultLocale: 'en',
+          currentLocale: 'en',
+        },
+      },
+      {
+        hosts: ['www.foo.com', 'foo.com', 'local.foo.com'],
+        config: {
+          url: 'foo.com',
+          name: 'Foo',
+          description: 'Foo description',
+        },
+      },
+    ]
+  }
+})
+```
 
 ## `url`
 
@@ -56,4 +93,4 @@ Whether to add trailing slashes to the URLs.
 
 - Type: `string`
 
-The default locale of the site.
+The default locale of the site._

--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -14,6 +14,7 @@ import {
 import { getSiteConfigStack, initSiteConfig, updateSiteConfig } from 'nuxt-site-config-kit'
 import { readPackageJSON } from 'pkg-types'
 import { validateSiteConfigStack } from 'site-config-stack'
+import { parseURL } from 'ufo'
 import { setupDevToolsUI } from './devtools'
 import { extendTypes } from './nuxt-kit'
 
@@ -30,6 +31,10 @@ export interface ModuleOptions extends SiteConfigInput {
    * @default false
    */
   debug: boolean
+  /**
+   * Configure multi-tenancy apps at build-time.
+   */
+  multiTenancy?: { hosts: string[], config: SiteConfigInput }[]
 }
 
 export interface ModuleRuntimeConfig {
@@ -95,6 +100,14 @@ export default defineNuxtModule<ModuleOptions>({
         stack: getSiteConfigStack().stack,
         version: version!,
         debug: config.debug,
+        multiTenancy: (config.multiTenancy || [])?.map((t) => {
+          // normalize hosts
+          t.hosts = (t.hosts || []).map(h => parseURL(h, 'https://').host).filter(Boolean) as string[]
+          if (!t.hosts.length) {
+            return false
+          }
+          return t
+        }).filter(Boolean),
       }
     })
 

--- a/packages/module/src/runtime/server/middleware/init.ts
+++ b/packages/module/src/runtime/server/middleware/init.ts
@@ -33,14 +33,6 @@ export default defineEventHandler(async (e) => {
     // @ts-expect-error untyped
     ...envSiteConfig(import.meta.env), // just in-case, shouldn't be needed
   })
-  siteConfig.push({
-    _context: 'runtimeEnv',
-    _priority: 0,
-    ...(runtimeConfig.site || {}),
-    ...(runtimeConfig.public.site || {}),
-    // @ts-expect-error untyped
-    ...envSiteConfig(import.meta.env), // just in-case, shouldn't be needed
-  })
   const buildStack = config.stack || []
   buildStack.forEach(c => siteConfig.push(c))
   // append route rules

--- a/packages/module/src/runtime/server/middleware/init.ts
+++ b/packages/module/src/runtime/server/middleware/init.ts
@@ -2,6 +2,7 @@ import type { HookSiteConfigInitContext } from '../../types'
 import { defineEventHandler } from 'h3'
 import { useNitroApp, useRuntimeConfig } from 'nitropack/runtime'
 import { createSiteConfigStack, envSiteConfig } from 'site-config-stack'
+import { parseURL } from 'ufo'
 import { useNitroOrigin } from '../composables/useNitroOrigin'
 
 export default defineEventHandler(async (e) => {
@@ -32,6 +33,14 @@ export default defineEventHandler(async (e) => {
     // @ts-expect-error untyped
     ...envSiteConfig(import.meta.env), // just in-case, shouldn't be needed
   })
+  siteConfig.push({
+    _context: 'runtimeEnv',
+    _priority: 0,
+    ...(runtimeConfig.site || {}),
+    ...(runtimeConfig.public.site || {}),
+    // @ts-expect-error untyped
+    ...envSiteConfig(import.meta.env), // just in-case, shouldn't be needed
+  })
   const buildStack = config.stack || []
   buildStack.forEach(c => siteConfig.push(c))
   // append route rules
@@ -40,6 +49,18 @@ export default defineEventHandler(async (e) => {
       _context: 'route-rules',
       ...e.context._nitro.routeRules.site,
     })
+  }
+  if (config.multiTenancy) {
+    // iterate to find the one with hosts that match
+    const host = parseURL(nitroOrigin).host
+    const tenant = config.multiTenancy?.find(t => t.hosts.includes(host))
+    if (tenant) {
+      siteConfig.push({
+        _context: `multi-tenancy:${host}`,
+        _priority: 0,
+        ...tenant.config,
+      })
+    }
   }
   const ctx: HookSiteConfigInitContext = { siteConfig, event: e }
   await nitroApp.hooks.callHook('site-config:init', ctx)

--- a/test/e2e/multiTenancy.test.ts
+++ b/test/e2e/multiTenancy.test.ts
@@ -1,0 +1,70 @@
+import { fileURLToPath } from 'node:url'
+import { $fetch, setup } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+process.env.NUXT_PUBLIC_SITE_URL = 'https://env.harlanzw.com'
+process.env.NUXT_PUBLIC_SITE_ENV = 'test'
+await setup({
+  rootDir: fileURLToPath(new URL('../fixtures/basic', import.meta.url)),
+  server: true,
+  build: true,
+  nuxtConfig: {
+    site: {
+      multiTenancy: [
+        {
+          hosts: ['www.example.com', 'example.com', 'local.example.com'],
+          config: {
+            name: 'Example',
+            description: 'Example description',
+            url: 'example.com', // canonical
+            defaultLocale: 'en',
+            currentLocale: 'en',
+          },
+        },
+        {
+          hosts: ['www.foo.com', 'foo.com', 'local.foo.com'],
+          config: {
+            url: 'foo.com',
+            name: 'Foo',
+            description: 'Foo description',
+          },
+        },
+      ],
+    },
+  },
+})
+
+describe('mutlitenancy', async () => {
+  it('example.com', async () => {
+    const s = await $fetch('/', {
+      headers: {
+        'x-forwarded-host': 'local.example.com',
+      },
+    })
+    const currentLocale = s.match(/<td data-currentlocale="true">(.+?)<\/td>/)?.[1]
+    const defaultLocale = s.match(/<td data-defaultlocale="true">(.+?)<\/td>/)?.[1]
+    const description = s.match(/<td data-description="true">(.+?)<\/td>/)?.[1]
+    const env = s.match(/<td data-env="true">(.+?)<\/td>/)?.[1]
+    const name = s.match(/<td data-name="true">(.+?)<\/td>/)?.[1]
+    const url = s.match(/<td data-url="true">(.+?)<\/td>/)?.[1]
+    expect(currentLocale).toBe('en')
+    expect(defaultLocale).toBe('en')
+    expect(description).toBe('Example description')
+    expect(env).toBe('test')
+    expect(name).toBe('Example')
+    expect(url).toBe('https://example.com')
+  })
+  it('foo.com', async () => {
+    const s = await $fetch('/', {
+      headers: {
+        'x-forwarded-host': 'local.foo.com',
+      },
+    })
+    const description = s.match(/<td data-description="true">(.+?)<\/td>/)?.[1]
+    const name = s.match(/<td data-name="true">(.+?)<\/td>/)?.[1]
+    const url = s.match(/<td data-url="true">(.+?)<\/td>/)?.[1]
+    expect(description).toBe('Foo description')
+    expect(name).toBe('Foo')
+    expect(url).toBe('https://foo.com')
+  })
+})

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -1,0 +1,22 @@
+import { resolve } from 'node:path'
+import NuxtSiteConfig from '../../../packages/module/src/module'
+
+// https://v3.nuxtjs.org/api/configuration/nuxt.config
+export default defineNuxtConfig({
+  modules: [
+    NuxtSiteConfig,
+  ],
+
+  alias: {
+    'site-config-stack': resolve(__dirname, '../../../packages/site-config/src'),
+  },
+
+  nitro: {
+    prerender: {
+      failOnError: false,
+      ignore: ['/'],
+    },
+  },
+
+  compatibilityDate: '2025-01-29',
+})

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -1,0 +1,37 @@
+<script lang="ts" setup>
+import { useSiteConfig } from '#imports'
+
+const siteConfig = useSiteConfig({ debug: true })
+
+const rows = [
+  ...Object.entries(siteConfig)
+    .filter(([key]) => key !== '_context')
+    .map(([key, value]) => {
+      return {
+        key,
+        value,
+      }
+    }),
+]
+</script>
+
+<template>
+  <div>
+    <table>
+      <thead>
+        <tr>
+          <th>Key</th>
+          <th>Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in rows" :key="row.key">
+          <td>{{ row.key }}</td>
+          <td v-bind="{ [`data-${row.key}`]: true }">
+            {{ row.value }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description


Multi-tenancy allows you to serve multiple sites with different configurations using a single Nuxt application. This is useful when you need to:
- Host multiple domains with different branding
- Serve region-specific content
- Maintain multiple sites with shared codebase

You can configure multi-tenancy using static configuration or dynamically at runtime.

## Usage

To use build-time multi-tenancy configuration you can use the `multiTenancy` option:

```ts
export default defineNuxtConfig({
  site: {
    multiTenancy: [
      {
        hosts: ['www.example.com', 'example.com', 'local.example.com'],
        config: {
          name: 'Example',
          url: 'example.com' // canonical
        },
      },
      {
        hosts: ['www.foo.com', 'foo.com', 'local.foo.com'],
        config: {
          name: 'Foo',
          url: 'foo.com', // canonical
          description: 'Foo description',
        },
      },
    ]
  }
})
```

Each multi-tenant configuration requires:

- `hosts`: An array of hostnames that should use this configuration

It's recommended to add any non-canonical hostnames to the `hosts` array to avoid duplicate content issues. For example,
www.* and non-www.* hostnames should use the same configuration.

- `config`: The site configuration to apply when the hostname matches

The config object supports all standard site configuration options plus any custom properties you need.

## How it works

1. When a request is received, the module checks the hostname against the configured hosts arrays
2. If a match is found, the corresponding config is applied
3. The configuration is made available through the `useSiteConfig()` composable


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
