### PR TITLE
fix: handle site config usage in middleware

### DIFF
--- a/packages/module/src/runtime/server/composables/useSiteConfig.ts
+++ b/packages/module/src/runtime/server/composables/useSiteConfig.ts
@@ -4,8 +4,12 @@ import type { NuxtSiteConfig } from '../../types'
 import { defu } from 'defu'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { createSiteConfigStack } from 'site-config-stack'
+import { logger } from '../util'
 
 export function useSiteConfig(e: H3Event, _options?: GetSiteConfigOptions): NuxtSiteConfig {
+  if (import.meta.dev && !e.context._initedSiteConfig) {
+    logger.warn('Site config has not been initialized yet. If you\'re trying to access site config in a server middleware then this not yet supported. See https://github.com/harlan-zw/nuxt-seo/issues/397')
+  }
   e.context.siteConfig = e.context.siteConfig || createSiteConfigStack()
   const options = defu(_options, useRuntimeConfig(e)['nuxt-site-config'], { debug: false })
   return e.context.siteConfig.get(options) as NuxtSiteConfig

--- a/packages/module/src/runtime/server/middleware/init.ts
+++ b/packages/module/src/runtime/server/middleware/init.ts
@@ -6,13 +6,13 @@ import { parseURL } from 'ufo'
 import { useNitroOrigin } from '../composables/useNitroOrigin'
 
 export default defineEventHandler(async (e) => {
-  if (e.context.siteConfig)
+  if (e.context._initedSiteConfig)
     return
   const runtimeConfig = useRuntimeConfig(e)
   // this does need to be a middleware so the nitro origin is always up to date
   const config = runtimeConfig['nuxt-site-config']
   const nitroApp = useNitroApp()
-  const siteConfig = createSiteConfigStack({
+  const siteConfig = e.context.siteConfig || createSiteConfigStack({
     debug: config.debug,
   })
   const nitroOrigin = useNitroOrigin(e)
@@ -57,4 +57,5 @@ export default defineEventHandler(async (e) => {
   const ctx: HookSiteConfigInitContext = { siteConfig, event: e }
   await nitroApp.hooks.callHook('site-config:init', ctx)
   e.context.siteConfig = ctx.siteConfig
+  e.context._initedSiteConfig = true
 })

--- a/packages/module/src/runtime/server/util.ts
+++ b/packages/module/src/runtime/server/util.ts
@@ -1,0 +1,7 @@
+import { createConsola } from 'consola'
+
+export const logger = /* #__PURE__ */ createConsola({
+  defaults: {
+    tag: 'nuxt-site-config',
+  },
+})


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

User-land Nitro middleware will always be registered before Nuxt module registered middleware, this leads to issues with trying to access the current site config in a middleware.

As there's no workaround for now without an upstream fix, I've added a warning when trying to access site config in a middleware.

As an alternative to using middleware end users should use the `site-config:init` Nitro hook and set any site config here. This will run inside the Site Config middleware so is guaranteed to return site config.

https://nuxtseo.com/docs/site-config/nitro-api/nitro-hooks#site-configinit

```ts
export default defineNitroPlugin((nitroApp) => {
  nitroApp.hooks.hook('site-config:init', ({ event, siteConfig }) => {
    const origin = useNitroOrigin(event)
    if (origin.startsWith('fr.')) {
      siteConfig.push({
        _context: 'french nitro plugin', // helps you debug
        name: 'Mon Site',
        url: 'https://fr.example.com',
      })
    }
  })
})
```

This also fixes setting the site config in a middleware.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

https://github.com/harlan-zw/nuxt-seo/issues/397

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
