### PR TITLE
fix: fix invalid locale code error

### DIFF
--- a/packages/module/src/runtime/app/plugins/i18n.ts
+++ b/packages/module/src/runtime/app/plugins/i18n.ts
@@ -46,9 +46,17 @@ export default defineNuxtPlugin({
           return url || undefined
         }),
         // @ts-expect-error untyped
-        defaultLocale: i18n.defaultLocale,
+        ddefaultLocale: computed(() => {
+          // @ts-expect-error untyped
+          const locales = toValue(i18n.locales)
+          return locales.find(l => l.code === i18n.defaultLocale)?.language || i18n.defaultLocale
+        }),
         // @ts-expect-error untyped
-        currentLocale: i18n.locale,
+        currentLocale: computed(() => {
+          // @ts-expect-error untyped
+          const properties = toValue(i18n.localeProperties)
+          return properties.language
+        }),
         // @ts-expect-error untyped
         description: computed(() => i18n.te('nuxtSiteConfig.description') ? i18n.t('nuxtSiteConfig.description') : undefined),
         // @ts-expect-error untyped


### PR DESCRIPTION
As described in [#45](https://github.com/harlan-zw/nuxt-seo-utils/issues/45), this corrects the currentLocale error while using custom locale codes.

Also has the "side effect" to correctly populate `lang` attribute on the <html> tag.

Thanks