### PR TITLE
fix: nullable chain for getting locales

### DIFF
--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -195,7 +195,7 @@ declare global {
       // @ts-expect-error untyped
       const baseUrl = nuxt.options.i18n?.baseUrl
       // @ts-expect-error untyped
-      const locale = nuxt.options.i18n?.locales.find(l => l.code === nuxt.options.i18n?.defaultLocale)
+      const locale = nuxt.options.i18n?.locales?.find(l => l.code === nuxt.options.i18n?.defaultLocale)
       updateSiteConfig({
         _context: '@nuxtjs/i18n',
         url: typeof baseUrl === 'string' ? baseUrl : undefined,


### PR DESCRIPTION
### Description

This PR fixes an error `Cannot read properties of undefined (reading 'find')` which occurs when the module in prepared and no i18n config is configured.

### Linked Issues
Resolves https://github.com/harlan-zw/nuxt-site-config/issues/48

