### PR TITLE
fix(stack): correct hostname check

### DIFF
--- a/packages/site-config/src/stack.ts
+++ b/packages/site-config/src/stack.ts
@@ -1,5 +1,5 @@
 import type { GetSiteConfigOptions, SiteConfigInput, SiteConfigResolved, SiteConfigStack } from './type'
-import { getQuery, hasProtocol, parseURL, withHttps } from 'ufo'
+import { getQuery, hasProtocol, parseURL, withHttps, parseHost } from 'ufo'
 import { toValue } from 'vue'
 
 export function normalizeSiteConfig(config: SiteConfigResolved) {
@@ -32,6 +32,7 @@ export function validateSiteConfigStack(stack: SiteConfigStack) {
     const val = resolved.url
     const context = resolved._context?.url || 'unknown'
     const url = parseURL(val)
+    const { hostname } = parseHost(url.host)
     if (!url.host)
       errors.push(`url "${val}" from ${context} is not absolute`)
     else if (url.pathname && url.pathname !== '/')
@@ -40,7 +41,7 @@ export function validateSiteConfigStack(stack: SiteConfigStack) {
       errors.push(`url "${val}" from ${context} should not contain a hash`)
     else if (Object.keys(getQuery(val)).length > 0)
       errors.push(`url "${val}" from ${context} should not contain a query`)
-    else if (url.host === 'localhost')
+    else if (hostname === 'localhost')
       errors.push(`url "${val}" from ${context} should not be localhost`)
   }
   return errors


### PR DESCRIPTION
### Description

I think the current host check is inaccurate as it could be `localhost:3000` which does not equal `localhost`. Checking for the hostname instead seems to make more sense.

### Linked Issues

n/a

### Additional context

n/a
