### PR TITLE
fix(stack): don't warn for localhost in development

### DIFF
--- a/packages/site-config/src/stack.ts
+++ b/packages/site-config/src/stack.ts
@@ -40,7 +40,7 @@ export function validateSiteConfigStack(stack: SiteConfigStack) {
       errors.push(`url "${val}" from ${context} should not contain a hash`)
     else if (Object.keys(getQuery(val)).length > 0)
       errors.push(`url "${val}" from ${context} should not contain a query`)
-    else if (url.host === 'localhost')
+    else if (url.host === 'localhost' && resolved.env !== 'development')
       errors.push(`url "${val}" from ${context} should not be localhost`)
   }
   return errors


### PR DESCRIPTION
### Description

I think it should be ok to run on `localhost` in development.

### Linked Issues

n/a

### Additional context

Nuxi currently sets the environment to `production` by default, e.g. when running `nuxi prepare`. That's why the warning will still be shown if `nuxi prepare` is run manually from the command line. Running `nuxi dev` sets the environment to `development` correctly, so in this case the warning should be muted as intended in this PR. For discussion on a sane default see:
- https://github.com/nuxt/cli/issues/460
