### PR TITLE
docs: change host check to include 'https://' prefix

### DIFF
--- a/docs/content/2.guides/3.runtime-site-config.md
+++ b/docs/content/2.guides/3.runtime-site-config.md
@@ -48,7 +48,7 @@ import { updateSiteConfig } from '#site-config/server/composables'
 
 export default defineEventHandler((e) => {
   const host = useNitroOrigin(e)
-  if (host.startsWith('admin.')) {
+  if (host.startsWith('https://admin.')) {
     updateSiteConfig(e, {
       name: 'Admin',
       indexable: false,


### PR DESCRIPTION
Unfortunately, the host is not the hostname, but also contains the protocol and port. Locally, I see `http://127.0.0.1:3101/`; in logs on hosted version it's `https://....`

<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
