### PR TITLE
fix: support IPv6 addresses in getNitroOrigin host parsing

### DIFF
--- a/packages/module/src/runtime/server/composables/getNitroOrigin.ts
+++ b/packages/module/src/runtime/server/composables/getNitroOrigin.ts
@@ -27,8 +27,9 @@ export function getNitroOrigin(e?: H3Event): string {
     protocol = getRequestProtocol(e, { xForwardedProto: true }) || protocol
   }
   if (typeof host === 'string' && host.includes(':')) {
-    port = host.split(':').pop()!
-    host = host.split(':')[0] || false
+    const hostParts = host.split(':')
+    port = hostParts.pop()!
+    host = hostParts.join(":") || false
   }
   port = port ? `:${port}` : ''
   return withTrailingSlash(`${protocol}://${host}${port}`)


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

For an origin like `"[::1]:3000"` that has an IPv6 host, the nitro origin was being parsed as `"http://[:3000"` because of an assumption in the number of colons during parsing. This PR updates getNitroOrigin to better handle ipv6 addresses

### Linked Issues
---

### Additional context
When running a nuxt app in dev mode, nitro can sometimes report `baseUrl` in `NUXT_VITE_NODE_OPTIONS` as `"http://[::1]:3000` (although it reports localhost when run with `--host` for some reason)