### PR TITLE
fix: support env for internal origin URL resolutions

### DIFF
--- a/packages/module/src/runtime/server/composables/getNitroOrigin.ts
+++ b/packages/module/src/runtime/server/composables/getNitroOrigin.ts
@@ -32,5 +32,8 @@ export function getNitroOrigin(e?: H3Event): string {
     host = hostParts.join(':') || false
   }
   port = port ? `:${port}` : ''
+  host = process.env.NUXT_SITE_HOST_OVERRIDE || host
+  port = process.env.NUXT_SITE_PORT_OVERRIDE || port
+
   return withTrailingSlash(`${protocol}://${host}${port}`)
 }


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Temporary solution for incorrect origins returned without ports discussed on [Discord](https://discord.com/channels/931135234261532713/1446682822873059419)
Added environment variables to override the returned host and port from getNitroOrigin
### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
