### PR TITLE
fix: incorrect property leads to 500 error

### DIFF
--- a/client/app.vue
+++ b/client/app.vue
@@ -55,7 +55,7 @@ function normaliseSiteConfigInput(_input: Partial<SiteConfigInput>) {
           <h1 text-xl flex items-center gap-2>
             <NIcon icon="carbon:settings-check" class="text-blue-300" />
             Site Config <NBadge class="text-sm">
-              {{ data?.runtimeConfig.version }}
+              {{ data?.version }}
             </NBadge>
           </h1>
         </div>


### PR DESCRIPTION
The following API return value does not include `runtimeConfig`.

https://github.com/harlan-zw/nuxt-site-config/blob/35ac24ffeabcb13d0687f4036c5bf1c090b540f1/packages/module/src/runtime/server/routes/__site-config__/debug.ts#L16-L21