### PR TITLE
docs: fix broken links and improve descriptions

### DIFF
--- a/docs/content/0.getting-started/0.introduction.md
+++ b/docs/content/0.getting-started/0.introduction.md
@@ -66,7 +66,7 @@ It aims to keep all these in sync, resulting in a single source of truth for sit
 
 ## How does it work?
 
-See [How it works](/docs/site-config/getting-started/how-it-works) for more details.
+See [How it works](/docs/site-config/guides/how-it-works) for more details.
 
 ## End goal
 

--- a/docs/content/0.getting-started/3.troubleshooting.md
+++ b/docs/content/0.getting-started/3.troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: "Troubleshooting Nuxt Site Config"
-description: Create minimal reproductions for Nuxt Site Config or just experiment with the module.
+description: Debug Nuxt Site Config issues using DevTools, config options, and minimal reproductions.
 navigation:
   title: "Troubleshooting"
 ---
@@ -45,3 +45,7 @@ When submitting an issue, it's important to provide as much information as possi
 The easiest way to do this is to create a minimal reproduction using the Stackblitz playgrounds:
 
 - [Basic](https://stackblitz.com/edit/nuxt-starter-zycxux?file=public%2F_robots.txt)
+
+## Debugging Tools
+
+- [Meta Tag Checker](/tools/meta-tag-checker) - Verify site URL appears correctly in meta tags

--- a/docs/content/4.api/4.create-site-path-resolver.md
+++ b/docs/content/4.api/4.create-site-path-resolver.md
@@ -41,3 +41,5 @@ Should the path be resolved to an absolute URL.
 
 - Type: `boolean`
 - Default: `false`
+
+Should the path include the base URL from the Nuxt app config.

--- a/docs/content/4.api/5.get-nitro-origin.md
+++ b/docs/content/4.api/5.get-nitro-origin.md
@@ -1,6 +1,6 @@
 ---
 title: getNitroOrigin()
-description: A runtime safe way of accessing the Nitro origin.
+description: Get the runtime origin URL safely across development, prerendering, and production environments.
 ---
 
 A utility function to get the Nitro origin from the request headers.

--- a/docs/content/4.nitro-api/3.get-site-indexable.md
+++ b/docs/content/4.nitro-api/3.get-site-indexable.md
@@ -1,6 +1,6 @@
 ---
 title: getSiteIndexable()
-description: Access the site config.
+description: Check if the current site is indexable within Nitro.
 ---
 
 Determine if the site is indexable by search engines.

--- a/docs/content/4.nitro-api/5.get-nitro-origin.md
+++ b/docs/content/4.nitro-api/5.get-nitro-origin.md
@@ -1,6 +1,6 @@
 ---
 title: getNitroOrigin()
-description: A runtime safe way of accessing the Nitro origin, within Nitro.
+description: Get the runtime origin URL safely within Nitro server handlers.
 ---
 
 Same as [getNitroOrigin()](/docs/site-config/api/get-nitro-origin) but you will need to provide the request context.


### PR DESCRIPTION
## Summary
- Fix broken internal link in introduction.md (how-it-works path)
- Fix getSiteIndexable description (was incorrectly describing site config access)
- Complete withBase option description in create-site-path-resolver.md
- Improve get-nitro-origin descriptions
- Add Meta Tag Checker link to troubleshooting

🤖 Generated with [Claude Code](https://claude.com/claude-code)