### PR TITLE
fix: hydrate site config in spa mode

### DIFF
--- a/packages/module/src/module.ts
+++ b/packages/module/src/module.ts
@@ -6,6 +6,7 @@ import {
   addServerHandler,
   addServerImportsDir,
   addServerPlugin,
+  addServerTemplate,
   addTemplate,
   addTypeTemplate,
   createResolver,
@@ -194,6 +195,11 @@ export {}
     nuxt.options.alias['#site-config'] = resolve('./runtime')
     // add site-config-stack to transpile
     nuxt.options.build.transpile.push('site-config-stack')
+
+    addServerTemplate({
+      filename: '#nuxt-site-config/no-ssr.mjs',
+      getContents: () => `export const NUXT_SITE_CONFIG_NO_SSR = ${nuxt.options.ssr === false}`,
+    })
 
     addPlugin({
       src: resolve('./runtime/app/plugins/0.siteConfig'),

--- a/packages/module/src/runtime/server/plugins/injectState.ts
+++ b/packages/module/src/runtime/server/plugins/injectState.ts
@@ -1,6 +1,8 @@
 import devalue from '@nuxt/devalue'
 import { defineNitroPlugin, getRouteRules } from 'nitropack/runtime'
 import { toValue } from 'vue'
+// @ts-expect-error virtual Nitro module
+import { NUXT_SITE_CONFIG_NO_SSR } from '#nuxt-site-config/no-ssr.mjs'
 import { getSiteConfig } from '../composables/getSiteConfig'
 
 const PRERENDER_NO_SSR_ROUTES = new Set(['/index.html', '/200.html', '/404.html'])
@@ -11,7 +13,8 @@ export default defineNitroPlugin(async (nitroApp) => {
     const routeOptions = getRouteRules(event)
     const isIsland = (process.env.NUXT_COMPONENT_ISLANDS && event.path.startsWith('/__nuxt_island'))
     const url = event.path
-    const noSSR = !!(process.env.NUXT_NO_SSR)
+    const noSSR = !!NUXT_SITE_CONFIG_NO_SSR
+      || !!(process.env.NUXT_NO_SSR)
       || event.context.nuxt?.noSSR
       || (routeOptions.ssr === false && !isIsland)
       || (import.meta.prerender ? PRERENDER_NO_SSR_ROUTES.has(url) : false)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,8 +24,8 @@ packages:
   - devtools
   - '!examples/**'
 overrides:
-  vue: ^3.5.38
   vitest-environment-nuxt: 1.0.1
+  vue: ^3.5.38
 catalog:
   '@antfu/eslint-config': ^9.0.0
   '@arethetypeswrong/cli': ^0.18.3

--- a/test/e2e/spa.test.ts
+++ b/test/e2e/spa.test.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from 'node:url'
+import { $fetch, setup } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../fixtures/spa', import.meta.url)),
+  server: true,
+  build: true,
+})
+
+describe('spa', () => {
+  it('injects site config into the non-ssr app shell', async () => {
+    const html = await $fetch<string>('/')
+
+    expect(html).toContain('window.__NUXT_SITE_CONFIG__=')
+    expect(html).toContain('SPA Site')
+    expect(html).toContain('spa.example.com')
+  })
+})

--- a/test/fixtures/spa/nuxt.config.ts
+++ b/test/fixtures/spa/nuxt.config.ts
@@ -1,0 +1,21 @@
+import { resolve } from 'node:path'
+import NuxtSiteConfig from '../../../packages/module/src/module'
+
+export default defineNuxtConfig({
+  ssr: false,
+
+  modules: [
+    NuxtSiteConfig,
+  ],
+
+  alias: {
+    'site-config-stack': resolve(__dirname, '../../../packages/site-config/src'),
+  },
+
+  site: {
+    name: 'SPA Site',
+    url: 'https://spa.example.com',
+  },
+
+  compatibilityDate: '2025-01-29',
+})

--- a/test/fixtures/spa/pages/index.vue
+++ b/test/fixtures/spa/pages/index.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import { computed, useSiteConfig } from '#imports'
+
+const siteConfig = useSiteConfig()
+const serialized = computed(() => JSON.stringify(siteConfig))
+</script>
+
+<template>
+  <pre data-site-config>{{ serialized }}</pre>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

Related to harlan-zw/nuxt-seo#393

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Nuxt apps with `ssr: false` rendered the SPA shell without `window.__NUXT_SITE_CONFIG__`, so the client plugin built an empty stack and `useSiteConfig()` returned `{}`. This adds a module-owned Nitro virtual flag for global no-SSR mode and covers the shell injection with a SPA fixture test.

The pnpm override order is also sorted so the required lint check passes.