### PR TITLE
docs: content audit sweep (grammar, links, structure)

### DIFF
--- a/docs/content/0.getting-started/0.introduction.md
+++ b/docs/content/0.getting-started/0.introduction.md
@@ -29,27 +29,11 @@ Ready to get started? Check out the [installation guide](/docs/site-config/getti
 
 ## Site Config Examples
 
-### `url`
-
-A canonical site URL is important for [SEO](/docs/nuxt-seo/getting-started/introduction) and performance.
-
-### `env`
-
-The environment the site is running in, important so we can disable indexing for non-production environments.
-
-See [this issue](https://github.com/nuxt/nuxt/issues/19819) on why we can't use `process.env.NODE_ENV`.
-
-### `indexable`
-
-Can the site be indexed by search engines? Used by [robots](/docs/robots/getting-started/introduction) and [sitemap](/docs/sitemap/getting-started/introduction) modules. Sometimes we have production sites that we don't want to be indexed.
-
-### `name`
-
-The name of the site is often used in meta tags and other SEO related tags.
-
-### `trailingSlash`
-
-Trailing slash consistency avoids duplicate content issues for SEO.
+- **`url`**: A canonical site URL is important for [SEO](/docs/nuxt-seo/getting-started/introduction) and performance.
+- **`env`**: The environment the site is running in, important so we can disable indexing for non-production environments. See [this issue](https://github.com/nuxt/nuxt/issues/19819) on why we can't use `process.env.NODE_ENV`.
+- **`indexable`**: Can the site be indexed by search engines? Used by [robots](/docs/robots/getting-started/introduction) and [sitemap](/docs/sitemap/getting-started/introduction) modules. Sometimes we have production sites that we don't want to be indexed.
+- **`name`**: The name of the site is often used in meta tags and other SEO related tags.
+- **`trailingSlash`**: Trailing slash consistency avoids duplicate content issues for SEO.
 
 ## What's the problem?
 
@@ -72,14 +56,8 @@ However, this has two major drawbacks:
 
 Yes. In fact, this module uses `site` on the runtime config under the hood.
 
-It aims to keep all these in sync, resulting in a single source of truth for site config.
+It aims to keep all these in sync, resulting in a single source of truth for site config. See [How it works](/docs/site-config/guides/how-it-works) for more details.
 
-## How does it work?
-
-See [How it works](/docs/site-config/guides/how-it-works) for more details.
-
-## End goal
-
-We should be able to spin up a multi-tenant or multi-lingual Nuxt app with minimal effort, and Nuxt modules should work, without any additional configuration.
+**End goal.** We should be able to spin up a multi-tenant or multi-lingual Nuxt app with minimal effort, and Nuxt modules should work, without any additional configuration.
 
 This is far off, but it sets a good direction for the module.

--- a/docs/content/0.getting-started/0.introduction.md
+++ b/docs/content/0.getting-started/0.introduction.md
@@ -1,13 +1,24 @@
 ---
-title: Introduction
+title: Nuxt Site Config
 description: Learn about the motivation behind Nuxt Site Config and a bit about how it works.
+navigation:
+  title: Introduction
+relatedPages:
+  - path: /docs/site-config/getting-started/installation
+    title: Install Nuxt Site Config
+  - path: /docs/site-config/guides/how-it-works
+    title: How it works
+  - path: /docs/nuxt-seo/guides/site-config
+    title: Understanding Site Config
 ---
 
-## Background
+## Why use Nuxt Site Config?
 
 Site config aims to be two things:
 - A single source of truth for site config, for end users and module authors. Multiple modules commonly share this config, filling a gap the Nuxt core does not cover.
 - A set of APIs for working with "writeable runtime config", for end-users and module authors.
+
+Ready to get started? Check out the [installation guide](/docs/site-config/getting-started/installation).
 
 ## Features
 
@@ -20,11 +31,11 @@ Site config aims to be two things:
 
 ### `url`
 
-A canonical site URL is important for [SEO](/docs/nuxt-seo/getting-started/introduction) and performance
+A canonical site URL is important for [SEO](/docs/nuxt-seo/getting-started/introduction) and performance.
 
 ### `env`
 
-The environment the site is running in, importing so we can disable indexing for non-production environments.
+The environment the site is running in, important so we can disable indexing for non-production environments.
 
 See [this issue](https://github.com/nuxt/nuxt/issues/19819) on why we can't use `process.env.NODE_ENV`.
 
@@ -34,11 +45,11 @@ Can the site be indexed by search engines? Used by [robots](/docs/robots/getting
 
 ### `name`
 
-The name of the site is often used in meta tags and other SEO related tags
+The name of the site is often used in meta tags and other SEO related tags.
 
 ### `trailingSlash`
 
-Trailing slashes are important for SEO and performance.
+Trailing slash consistency avoids duplicate content issues for SEO.
 
 ## What's the problem?
 
@@ -69,6 +80,6 @@ See [How it works](/docs/site-config/guides/how-it-works) for more details.
 
 ## End goal
 
-We should be able to spin up multi-tenant or multi-lingual Nuxt app with minimal effort, and Nuxt modules should work, without any additional configuration.
+We should be able to spin up a multi-tenant or multi-lingual Nuxt app with minimal effort, and Nuxt modules should work, without any additional configuration.
 
 This is far off, but it sets a good direction for the module.

--- a/docs/content/0.getting-started/1.installation.md
+++ b/docs/content/0.getting-started/1.installation.md
@@ -27,10 +27,6 @@ npx skilld add nuxt-site-config
 
 After installing the module, visit `/__site-config__/debug.json` to see the current site config, or check the Site Config tab in Nuxt DevTools.
 
-## Configuration
-
-For Nuxt apps, see the [Site Config Guide](/docs/site-config/guides/how-it-works) for usage.
-
 ## Module Kit Usage
 
 Use the install function in your module:

--- a/docs/content/0.getting-started/1.installation.md
+++ b/docs/content/0.getting-started/1.installation.md
@@ -1,8 +1,15 @@
 ---
-title: 'Install Nuxt Site Config'
-description: 'Get started with Nuxt Site Config by installing the dependency to your project.'
+title: Install Nuxt Site Config
+description: Get started with Nuxt Site Config by installing the dependency to your project.
 navigation:
-  title: 'Installation'
+  title: Installation
+relatedPages:
+  - path: /docs/site-config/guides/setting-site-config
+    title: Recommended Config
+  - path: /docs/site-config/guides/how-it-works
+    title: How it works
+  - path: /docs/nuxt-seo/guides/site-config
+    title: Understanding Site Config
 ---
 
 ## Setup Module
@@ -15,6 +22,10 @@ Generate an Agent Skill for this package using [skilld](https://github.com/harla
 npx skilld add nuxt-site-config
 ```
 ::
+
+## Verifying Installation
+
+After installing the module, visit `/__site-config__/debug.json` to see the current site config, or check the Site Config tab in Nuxt DevTools.
 
 ## Configuration
 
@@ -43,3 +54,11 @@ export default defineNuxtModule({
 ```
 
 That's it. Explore the documentation to learn more.
+
+## Next Steps
+
+You've successfully installed Nuxt Site Config. Here's the recommended reading path:
+
+1. **[Recommended Config](/docs/site-config/guides/setting-site-config)** - Set your site `url`, `env`, and `name`
+2. **[How it works](/docs/site-config/guides/how-it-works)** - Understand config resolution order
+3. **[Runtime Site Config](/docs/site-config/guides/runtime-site-config)** - Set config dynamically per-request

--- a/docs/content/0.getting-started/3.troubleshooting.md
+++ b/docs/content/0.getting-started/3.troubleshooting.md
@@ -1,8 +1,15 @@
 ---
-title: "Troubleshooting Nuxt Site Config"
+title: Troubleshooting Nuxt Site Config
 description: Debug Nuxt Site Config issues using DevTools, config options, and minimal reproductions.
 navigation:
-  title: "Troubleshooting"
+  title: Troubleshooting
+relatedPages:
+  - path: /docs/site-config/guides/how-it-works
+    title: How it works
+  - path: /docs/site-config/api/config
+    title: Nuxt Config
+  - path: /docs/nuxt-seo/getting-started/troubleshooting
+    title: Troubleshooting
 ---
 
 ## Debugging

--- a/docs/content/0.getting-started/3.troubleshooting.md
+++ b/docs/content/0.getting-started/3.troubleshooting.md
@@ -14,16 +14,7 @@ relatedPages:
 
 ## Debugging
 
-### Nuxt DevTools
-
-The best tool for debugging is the Nuxt DevTools integration with Nuxt Site Config.
-
-This will show you the current site config.
-
-### Debug Config
-
-Nuxt Site Config comes with a Nuxt DevTools integration. The easiest way to debug is to open your DevTools
-and navigate to the Site Config tab.
+The best tool for debugging is the Nuxt DevTools integration with Nuxt Site Config. The easiest way to debug is to open your DevTools and navigate to the Site Config tab, which will show you the current site config.
 
 If you'd like to debug outside of development, you will need to enable the debug mode.
 
@@ -35,15 +26,7 @@ export default defineNuxtConfig({
 })
 ```
 
-### Debugging Runtime
-
-Visit the endpoint `/__site-config__/debug.json` to see the current site config debug output.
-
-### Debugging Build Time
-
-The build step generates a static file at `/__site-config__/debug.json`.
-
-You can view this file to see the build time site config debug output.
+With debug mode enabled, visit the endpoint `/__site-config__/debug.json` to see the current site config debug output at runtime. The build step also generates a static file at the same path for the build time site config debug output.
 
 ## Submitting an Issue
 

--- a/docs/content/2.guides/0.setting-site-config.md
+++ b/docs/content/2.guides/0.setting-site-config.md
@@ -61,7 +61,5 @@ export default defineNuxtConfig({
 })
 ```
 
-## Runtime Site Config
-
-Sometimes you need to set your site config programmatically. The module fully supports this, see the [Runtime Site Config](/docs/site-config/guides/runtime-site-config) guide to
+**Runtime site config.** Sometimes you need to set your site config programmatically. The module fully supports this, see the [Runtime Site Config](/docs/site-config/guides/runtime-site-config) guide to
 learn how.

--- a/docs/content/2.guides/0.setting-site-config.md
+++ b/docs/content/2.guides/0.setting-site-config.md
@@ -1,11 +1,18 @@
 ---
 title: Recommended Config
 description: Learn how to set site config in your Nuxt app.
+relatedPages:
+  - path: /docs/site-config/guides/how-it-works
+    title: How it works
+  - path: /docs/site-config/guides/runtime-site-config
+    title: Runtime Site Config
+  - path: /docs/nuxt-seo/guides/site-config
+    title: Understanding Site Config
 ---
 
 Site config can be set from many different sources from each environment.
 
-For a full list see [how it works](/docs/site-config/getting-started/how-it-works).
+For a full list see [how it works](/docs/site-config/guides/how-it-works).
 
 At a minimum, it's recommended you provide a `url`, `env` and `name` for your site.
 
@@ -38,7 +45,7 @@ NUXT_SITE_ENV="staging"
 
 If you need to set your site config programmatically, you can use the `site-config:resolve` hook with `updateSiteConfig` from the kit.
 
-```ts
+```ts [nuxt.config.ts]
 import { updateSiteConfig } from 'nuxt-site-config/kit'
 
 export default defineNuxtConfig({

--- a/docs/content/2.guides/1.how-it-works.md
+++ b/docs/content/2.guides/1.how-it-works.md
@@ -1,9 +1,16 @@
 ---
 title: How it works
 description: Learn how the Nuxt Site Config module works, so you can get the most out of it.
+relatedPages:
+  - path: /docs/site-config/guides/setting-site-config
+    title: Recommended Config
+  - path: /docs/site-config/api/config
+    title: Nuxt Config
+  - path: /docs/robots/guides/how-it-works
+    title: How Nuxt Robots Works
 ---
 
-# Config Sources
+## Config Sources
 
 Site config resolves from the following sources, in order of precedence:
 

--- a/docs/content/2.guides/1.how-it-works.md
+++ b/docs/content/2.guides/1.how-it-works.md
@@ -10,8 +10,6 @@ relatedPages:
     title: How Nuxt Robots Works
 ---
 
-## Config Sources
-
 Site config resolves from the following sources, in order of precedence:
 
 ## Build Time
@@ -42,35 +40,16 @@ When deploying to supported platforms, `url` and `name` are automatically popula
 As of v4, `site.name` is no longer inferred from your project directory or `package.json`. It will only be auto-populated from CI platform env vars listed above, or from explicit config. See the [v4 release notes](/docs/site-config/releases/v4).
 ::
 
-### 3. Module overrides
-
-Build time site config provided by modules.
-
-### 4. Nuxt Config `site` key
-
-Site config provided by the user in the Nuxt config.
-
-### 5. Runtime Config and Environment Variables
-
-Site config provided by the user at runtime. `runtimeConfig.public.site` and associated environment variables (e.g. `NUXT_SITE_URL`, `NUXT_SITE_NAME`).
-
-### 6. Nuxt Hook
-
-The `site-config:resolve` hook fires to allow any final build time modifications to the config.
+3. **Module overrides**: Build time site config provided by modules.
+4. **Nuxt Config `site` key**: Site config provided by the user in the Nuxt config.
+5. **Runtime Config and Environment Variables**: Site config provided by the user at runtime. `runtimeConfig.public.site` and associated environment variables (e.g. `NUXT_SITE_URL`, `NUXT_SITE_NAME`).
+6. **Nuxt Hook**: The `site-config:resolve` hook fires to allow any final build time modifications to the config.
 
 ## SSR / Nitro Runtime
 
-### 1. Request URL
-
-The request URL determines the site URL at runtime.
-
-### 2. Build Time Site Config
-
-Config resolved in the build step, stored on `runtimeConfig['nuxt-site-config'].stack`.
-
-### 3. Route Rules
-
-Config resolved from the route rules of the request path, the `site` key. This allows for multi-site support.
+1. **Request URL**: The request URL determines the site URL at runtime.
+2. **Build Time Site Config**: Config resolved in the build step, stored on `runtimeConfig['nuxt-site-config'].stack`.
+3. **Route Rules**: Config resolved from the route rules of the request path, the `site` key. This allows for multi-site support.
 
 ## CSR Runtime
 

--- a/docs/content/2.guides/2.runtime-site-config.md
+++ b/docs/content/2.guides/2.runtime-site-config.md
@@ -1,6 +1,13 @@
 ---
 title: Runtime Site Config
 description: Learn how to set site config at runtime in your Nuxt app.
+relatedPages:
+  - path: /docs/site-config/guides/multi-tenancy
+    title: Multi-Tenancy
+  - path: /docs/site-config/nitro-api/update-site-config
+    title: updateSiteConfig()
+  - path: /docs/nuxt-seo/guides/site-config
+    title: Understanding Site Config
 ---
 
 Site config can be set from many different sources from each environment.
@@ -12,7 +19,7 @@ even allowing [multi-tenancy](/docs/site-config/guides/multi-tenancy).
 
 When setting site config at runtime, it's important to set it as early as possible on the server.
 
-This is because modules will be using site config to generate your app, for example if you're using Nuxt SEO, site
+This is because modules will be using site config to generate your app. For example, if you're using Nuxt SEO, site
 config drives `sitemap.xml` and `robots.txt` generation.
 
 Therefore, it's recommended to set it either within a Nitro plugin or middleware.
@@ -22,7 +29,7 @@ Therefore, it's recommended to set it either within a Nitro plugin or middleware
 A Nitro plugin is useful when you want to set site config based on a static condition, such as the environment
 or based on a result from a database.
 
-Because Site Config is attached to a H3 Request context, you will need to use the `site-config:init` hook to set it.
+Because Site Config is attached to an H3 Request context, you will need to use the `site-config:init` hook to set it.
 
 For example, here we are setting site config based on a database query:
 

--- a/docs/content/2.guides/3.multi-tenancy.md
+++ b/docs/content/2.guides/3.multi-tenancy.md
@@ -1,6 +1,13 @@
 ---
 title: Multi-Tenancy
 description: Learn how to serve multiple sites with different configurations based on the hostname.
+relatedPages:
+  - path: /docs/site-config/guides/runtime-site-config
+    title: Runtime Site Config
+  - path: /docs/site-config/nitro-api/nitro-hooks
+    title: Nitro Hooks
+  - path: /docs/nuxt-seo/guides/site-config
+    title: Understanding Site Config
 ---
 
 ## Introduction
@@ -16,7 +23,7 @@ You can configure multi-tenancy using static configuration or dynamically at [ru
 
 To use build-time multi-tenancy configuration you can use the `multiTenancy` option:
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   site: {
     multiTenancy: [
@@ -66,7 +73,7 @@ Runtime multi-tenancy is useful when you need to:
 - Handle dynamic subdomains
 - Implement A/B testing scenarios
 
-To use get started with runtime multi-tenancy you'll need to create a Nitro plugin.
+To get started with runtime multi-tenancy you'll need to create a Nitro plugin.
 
 ```ts [server/plugins/site-config.ts]
 import { getNitroOrigin } from '#site-config/server/composables'

--- a/docs/content/2.guides/4.i18n.md
+++ b/docs/content/2.guides/4.i18n.md
@@ -1,6 +1,13 @@
 ---
 title: I18n Integration
 description: How to use the Nuxt Site Config module with @nuxtjs/i18n or nuxt-i18n-micro.
+relatedPages:
+  - path: /docs/site-config/guides/setting-site-config
+    title: Recommended Config
+  - path: /docs/site-config/guides/multi-tenancy
+    title: Multi-Tenancy
+  - path: /docs/sitemap/guides/i18n
+    title: I18n
 ---
 
 Site Config integrates automatically with both [@nuxtjs/i18n](https://i18n.nuxtjs.org/) and [nuxt-i18n-micro](https://nuxt.com/modules/nuxt-i18n-micro). You do not need extra configuration; Site Config detects and enables the integration when your app installs either module.

--- a/docs/content/4.api/0.use-site-config.md
+++ b/docs/content/4.api/0.use-site-config.md
@@ -1,6 +1,13 @@
 ---
 title: useSiteConfig()
 description: How to access site config within a Nuxt context.
+relatedPages:
+  - path: /docs/site-config/nitro-api/use-site-config
+    title: getSiteConfig()
+  - path: /docs/site-config/api/update-site-config
+    title: updateSiteConfig()
+  - path: /docs/nuxt-seo/guides/site-config
+    title: Understanding Site Config
 ---
 
 Access the current site config within a Nuxt context.
@@ -28,7 +35,7 @@ const siteConfig = useSiteConfig()
 
 Provides a `_context` object to track the source of what sets the site config.
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   site: {
     name: 'My Site',

--- a/docs/content/4.api/1.update-site-config.md
+++ b/docs/content/4.api/1.update-site-config.md
@@ -1,14 +1,20 @@
 ---
 title: updateSiteConfig()
 description: Learn how to modify site config at runtime.
+relatedPages:
+  - path: /docs/site-config/nitro-api/update-site-config
+    title: updateSiteConfig()
+  - path: /docs/site-config/api/use-site-config
+    title: useSiteConfig()
+  - path: /docs/site-config/guides/runtime-site-config
+    title: Runtime Site Config
 ---
 
 Modify the site config at runtime. You can provide any config to this function, such as the [recommended config](/docs/site-config/guides/how-it-works).
 
-:u-badge{label="Warning" color="amber"}
-
-When using this, you will need to run it as early as possible in the Nuxt lifecycle to avoid conflicts with other modules.
-It's recommended to use the Nitro [updateSiteConfig](/docs/site-config/nitro-api/update-site-config) API instead.
+::warning
+When using this, you will need to run it as early as possible in the Nuxt lifecycle to avoid conflicts with other modules. It's recommended to use the Nitro [updateSiteConfig](/docs/site-config/nitro-api/update-site-config) API instead.
+::
 
 ## Usage
 

--- a/docs/content/4.api/4.create-site-path-resolver.md
+++ b/docs/content/4.api/4.create-site-path-resolver.md
@@ -1,6 +1,13 @@
 ---
 title: createSitePathResolver()
 description: Create a function to resolve a path relative to the site.
+relatedPages:
+  - path: /docs/site-config/nitro-api/create-site-path-resolver
+    title: createSitePathResolver()
+  - path: /docs/site-config/api/get-nitro-origin
+    title: getNitroOrigin()
+  - path: /docs/site-config/api/config
+    title: Nuxt Config
 ---
 
 A utility function to resolve a path in a number of ways while taking into account the `url`, `trailingSlash` and `baseURL`
@@ -44,4 +51,4 @@ Whether to resolve the path to an absolute URL.
 - Type: `boolean`
 - Default: `false`
 
-Should the path include the base URL from the Nuxt app config.
+Whether to include the base URL from the Nuxt app config.

--- a/docs/content/4.api/5.get-nitro-origin.md
+++ b/docs/content/4.api/5.get-nitro-origin.md
@@ -1,6 +1,13 @@
 ---
 title: getNitroOrigin()
 description: Get the runtime origin URL safely across development, prerendering, and production environments.
+relatedPages:
+  - path: /docs/site-config/nitro-api/get-nitro-origin
+    title: getNitroOrigin()
+  - path: /docs/site-config/api/create-site-path-resolver
+    title: createSitePathResolver()
+  - path: /docs/site-config/guides/how-it-works
+    title: How it works
 ---
 
 A utility function to get the Nitro origin from the request headers.

--- a/docs/content/4.api/config.md
+++ b/docs/content/4.api/config.md
@@ -1,25 +1,29 @@
 ---
 title: Nuxt Config
 description: The config options available for Nuxt Site Config.
+relatedPages:
+  - path: /docs/site-config/guides/how-it-works
+    title: How it works
+  - path: /docs/site-config/guides/setting-site-config
+    title: Recommended Config
+  - path: /docs/robots/api/config
+    title: Nuxt Config
 ---
 
-## `enabled`
+## `enabled: boolean`{lang="ts"}
 
-- Type: `boolean`{lang="ts"}
 - Default: `true`{lang="ts"}
 
 Whether site config activates for this project.
 
-## `debug`
+## `debug: boolean`{lang="ts"}
 
-- Type: `boolean`
-- Default: `false`
+- Default: `false`{lang="ts"}
 
 Whether to activate debug mode for site config.
 
-## `multiTenancy`
+## `multiTenancy: { hosts: string[]; config: SiteConfigInput }[]`{lang="ts"}
 
-- Type: `{ hosts: string[]; config: SiteConfigInput }[]`{lang="ts"}
 - Default: `[]`{lang="ts"}
 
 Configure multiple sites with different configurations based on the host. Each site configuration requires:
@@ -27,7 +31,7 @@ Configure multiple sites with different configurations based on the host. Each s
 - `hosts`: An array of hostnames that should use this configuration
 - `config`: The site configuration to use when the hostname matches
 
-```ts [Example]
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   site: {
     multiTenancy: [
@@ -54,43 +58,34 @@ export default defineNuxtConfig({
 })
 ```
 
-## `url`
-
-- Type: `string`
+## `url: string`{lang="ts"}
 
 The canonical site URL. On supported CI platforms (Vercel, [Netlify](https://netlify.com), Cloudflare Pages), this is automatically populated from platform environment variables if not explicitly set. See [How it works](/docs/site-config/guides/how-it-works) for details.
 
-## `env`
+## `env: string`{lang="ts"}
 
-- Type: `string`
-- Default: `process.env.NODE_ENV`
+- Default: `process.env.NODE_ENV`{lang="ts"}
 
 The environment the site is running in.
 
 See [this issue](https://github.com/nuxt/nuxt/issues/19819) on why we can't use `process.env.NODE_ENV`.
 
-## `name`
-
-- Type: `string`
+## `name: string`{lang="ts"}
 
 The name of the site. On [Vercel](https://vercel.com) and Netlify, this is automatically populated from platform environment variables if not explicitly set. See [How it works](/docs/site-config/guides/how-it-works) for details.
 
-## `indexable`
+## `indexable: boolean`{lang="ts"}
 
-- Type: `boolean`
-- Default: `siteConfig.env === 'production'` (where `env` defaults to `process.env.NODE_ENV`)
+- Default: `siteConfig.env === 'production'`{lang="ts"} (where `env` defaults to `process.env.NODE_ENV`)
 
-Can the site be indexed by search engines.
+Whether the site can be indexed by search engines.
 
-## `trailingSlash`
+## `trailingSlash: boolean`{lang="ts"}
 
-- Type: `boolean`
-- Default: `false`
+- Default: `false`{lang="ts"}
 
 Whether to add trailing slashes to the URLs.
 
-## `defaultLocale`
-
-- Type: `string`
+## `defaultLocale: string`{lang="ts"}
 
 The default locale of the site.

--- a/docs/content/4.api/nuxt-hooks.md
+++ b/docs/content/4.api/nuxt-hooks.md
@@ -1,6 +1,13 @@
 ---
 title: Nuxt Hooks
 description: Learn how to use Nuxt Hooks to customize your site config.
+relatedPages:
+  - path: /docs/site-config/nitro-api/nitro-hooks
+    title: Nitro Hooks
+  - path: /docs/site-config/guides/how-it-works
+    title: How it works
+  - path: /docs/robots/api/nuxt-hooks
+    title: Nuxt Hooks
 ---
 
 ## `site-config:resolve`
@@ -11,7 +18,7 @@ Modify the build time site config after the module resolves it.
 
 It's recommended to use runtime [Nitro hooks](/docs/site-config/nitro-api/nitro-hooks) if you need to modify the site config at runtime.
 
-```ts
+```ts [nuxt.config.ts]
 import { updateSiteConfig } from 'nuxt-site-config/kit'
 
 export default defineNuxtConfig({

--- a/docs/content/4.nitro-api/0.use-site-config.md
+++ b/docs/content/4.nitro-api/0.use-site-config.md
@@ -1,6 +1,13 @@
 ---
 title: getSiteConfig()
 description: How to use Site Config within Nitro.
+relatedPages:
+  - path: /docs/site-config/api/use-site-config
+    title: useSiteConfig()
+  - path: /docs/site-config/nitro-api/update-site-config
+    title: updateSiteConfig()
+  - path: /docs/site-config/nitro-api/nitro-hooks
+    title: Nitro Hooks
 ---
 
 Access the current site config within a Nitro event handler. Requires an `H3Event` as the first parameter.

--- a/docs/content/4.nitro-api/1.update-site-config.md
+++ b/docs/content/4.nitro-api/1.update-site-config.md
@@ -1,14 +1,21 @@
 ---
 title: updateSiteConfig()
 description: How to update Site Config within Nitro.
+relatedPages:
+  - path: /docs/site-config/api/update-site-config
+    title: updateSiteConfig()
+  - path: /docs/site-config/nitro-api/use-site-config
+    title: getSiteConfig()
+  - path: /docs/site-config/guides/runtime-site-config
+    title: Runtime Site Config
 ---
 
 Same as [updateSiteConfig](/docs/site-config/api/update-site-config) but you will need to provide the request context.
 
-:u-badge{label="Warning" color="amber"}
-
-When using this, you will to run it as early as possible within the request lifecycle to avoid conflicts. It's
+::warning
+When using this, you will need to run it as early as possible within the request lifecycle to avoid conflicts. It's
 recommended to run this either in a Nitro plugin or a nitro middleware.
+::
 
 ## Usage
 

--- a/docs/content/4.nitro-api/3.get-site-indexable.md
+++ b/docs/content/4.nitro-api/3.get-site-indexable.md
@@ -1,6 +1,13 @@
 ---
 title: getSiteIndexable()
 description: Check if the current site is indexable within Nitro.
+relatedPages:
+  - path: /docs/site-config/nitro-api/use-site-config
+    title: getSiteConfig()
+  - path: /docs/site-config/api/config
+    title: Nuxt Config
+  - path: /docs/robots/getting-started/introduction
+    title: Nuxt Robots
 ---
 
 Determine if the site is indexable by search engines.

--- a/docs/content/4.nitro-api/4.create-site-path-resolver.md
+++ b/docs/content/4.nitro-api/4.create-site-path-resolver.md
@@ -1,6 +1,13 @@
 ---
 title: createSitePathResolver()
 description: Create a function to resolve a path relative to the site within Nitro.
+relatedPages:
+  - path: /docs/site-config/api/create-site-path-resolver
+    title: createSitePathResolver()
+  - path: /docs/site-config/nitro-api/get-nitro-origin
+    title: getNitroOrigin()
+  - path: /docs/site-config/nitro-api/nitro-hooks
+    title: Nitro Hooks
 ---
 
 Same as [createSitePathResolver()](/docs/site-config/api/create-site-path-resolver) but you will need to provide the request context.

--- a/docs/content/4.nitro-api/5.get-nitro-origin.md
+++ b/docs/content/4.nitro-api/5.get-nitro-origin.md
@@ -1,6 +1,13 @@
 ---
 title: getNitroOrigin()
 description: Get the runtime origin URL safely within Nitro server handlers.
+relatedPages:
+  - path: /docs/site-config/api/get-nitro-origin
+    title: getNitroOrigin()
+  - path: /docs/site-config/nitro-api/create-site-path-resolver
+    title: createSitePathResolver()
+  - path: /docs/site-config/nitro-api/use-site-config
+    title: getSiteConfig()
 ---
 
 Same as [getNitroOrigin()](/docs/site-config/api/get-nitro-origin) but you will need to provide the request context.

--- a/docs/content/4.nitro-api/nitro-hooks.md
+++ b/docs/content/4.nitro-api/nitro-hooks.md
@@ -1,6 +1,13 @@
 ---
 title: Nitro Hooks
 description: Learn how to use Nitro Hooks to customize your site config.
+relatedPages:
+  - path: /docs/site-config/api/nuxt-hooks
+    title: Nuxt Hooks
+  - path: /docs/site-config/guides/multi-tenancy
+    title: Multi-Tenancy
+  - path: /docs/site-config/guides/runtime-site-config
+    title: Runtime Site Config
 ---
 
 ## `site-config:init`

--- a/docs/content/4.releases/4.v4.md
+++ b/docs/content/4.releases/4.v4.md
@@ -81,9 +81,7 @@ v4 removes the legacy `#internal/nuxt-site-config` import path. Use the document
 
 ## ✨ New Features
 
-### 🎯 Named Priority Constants
-
-Site config priority levels are now exposed as named constants for better readability when setting config priorities:
+**🎯 Named Priority Constants.** Site config priority levels are now exposed as named constants for better readability when setting config priorities:
 
 ```ts
 import { SiteConfigPriority } from 'site-config-stack'

--- a/docs/content/4.releases/4.v4.md
+++ b/docs/content/4.releases/4.v4.md
@@ -1,6 +1,6 @@
 ---
 title: v4.0.0
-description: Release notes for v4.0.0.
+description: Release notes for Nuxt Site Config v4.0.0.
 ---
 
 ## ⚠️ Breaking Changes
@@ -11,7 +11,7 @@ Previously, `site.name` was automatically inferred from your `package.json` `nam
 
 You must now explicitly set `site.name`:
 
-```ts [nuxt.config]
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   site: {
     name: 'My Website',

--- a/docs/content/4.releases/5.v3.md
+++ b/docs/content/4.releases/5.v3.md
@@ -1,6 +1,6 @@
 ---
 title: v3.0.0
-description: Release notes for v3.0.0.
+description: Release notes for Nuxt Site Config v3.0.0.
 ---
 
 ## ⚠️ Breaking Changes
@@ -10,7 +10,7 @@ description: Release notes for v3.0.0.
 If you were configuring your site config using the [app.config.ts](https://nuxt.com/docs/guide/directory-structure/app-config) file, you will need to move your configuration to the `nuxt.config.ts` file
 or set up [runtime site config](/docs/site-config/guides/runtime-site-config).
 
-```ts [nuxt.config]
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   site: {
     url: 'https://example.com',


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation

### 📚 Description

Docs-only sweep, part of a content audit across all Nuxt SEO module docs. Everything is under `docs/content/**`.

- Fixed the "importing so we can disable indexing" typo (important) and rewrote the unsupported "trailing slashes are important for SEO and performance" claim; the real concern is URL consistency, not performance.
- Introduction conformed to the "Why use Nuxt Site Config?" shape used by the other module docs; the stray body-level `# Config Sources` H1 in how-it-works demoted to match every other page.
- Installation gained a "Verifying Installation" section (grounded in the existing troubleshooting content) and a numbered next-steps list.
- Config reference headings folded to `## option: type`.
- Guides renumbered (three files shared `3.`, one had no prefix). URLs unchanged.
