### PR TITLE
chore: code cleanup sweep

### DIFF
--- a/packages/module/src/runtime/app/composables/utils.ts
+++ b/packages/module/src/runtime/app/composables/utils.ts
@@ -3,12 +3,12 @@ import type { VueCreateSitePathResolverOptions } from '../../types'
 import { fixSlashes, resolveSitePath } from 'site-config-stack/urls'
 import { computed, unref } from 'vue'
 import { useRuntimeConfig } from '#app'
-import { useNitroOrigin } from './useNitroOrigin'
+import { getNitroOrigin } from './getNitroOrigin'
 import { useSiteConfig } from './useSiteConfig'
 
 export function createSitePathResolver(options: VueCreateSitePathResolverOptions = {}): (path: MaybeRef<string>) => Ref<string> {
   const siteConfig = useSiteConfig()
-  const nitroOrigin = useNitroOrigin()
+  const nitroOrigin = getNitroOrigin()
   const nuxtBase = useRuntimeConfig().app.baseURL || '/'
   return (path: MaybeRef<string>) => {
     // don't use any composables within here
@@ -29,7 +29,7 @@ export function withSiteTrailingSlash(path: MaybeRef<string>): ComputedRef<strin
 
 export function withSiteUrl(path: MaybeRef<string>, options: VueCreateSitePathResolverOptions = {}): ComputedRef<string> {
   const siteConfig = useSiteConfig()
-  const nitroOrigin = useNitroOrigin()
+  const nitroOrigin = getNitroOrigin()
   const base = useRuntimeConfig().app.baseURL || '/'
   return computed(() => {
     return resolveSitePath(unref(path), {


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

Swept the package src dirs for dead code, duplication, and unused deps. The codebase was already clean; the one real finding was `app/composables/utils.ts` calling the deprecated `useNitroOrigin()` wrapper internally instead of `getNitroOrigin()` directly, unlike the server-side equivalent which already used the non-deprecated function. No public API or behavior changes.