### PR TITLE
feat: use Nuxt envName as site env fallback

### DIFF
--- a/docs/content/0.getting-started/0.introduction.md
+++ b/docs/content/0.getting-started/0.introduction.md
@@ -30,7 +30,7 @@ Ready to get started? Check out the [installation guide](/docs/site-config/getti
 ## Site Config Examples
 
 - **`url`**: A canonical site URL is important for [SEO](/docs/nuxt-seo/getting-started/introduction) and performance.
-- **`env`**: The environment the site is running in, important so we can disable indexing for non-production environments. See [this issue](https://github.com/nuxt/nuxt/issues/19819) on why we can't use `process.env.NODE_ENV`.
+- **`env`**: The environment the site is running in, important so we can disable indexing for non-production environments. Defaults to Nuxt's current environment name.
 - **`indexable`**: Can the site be indexed by search engines? Used by [robots](/docs/robots/getting-started/introduction) and [sitemap](/docs/sitemap/getting-started/introduction) modules. Sometimes we have production sites that we don't want to be indexed.
 - **`name`**: The name of the site is often used in meta tags and other SEO related tags.
 - **`trailingSlash`**: Trailing slash consistency avoids duplicate content issues for SEO.

--- a/docs/content/2.guides/1.how-it-works.md
+++ b/docs/content/2.guides/1.how-it-works.md
@@ -20,7 +20,7 @@ System details relate to the environment the app is running in.
 
 ```ts
 export default {
-  env: process.env.NODE_ENV,
+  env: import.meta.envName || process.env.NODE_ENV,
 }
 ```
 

--- a/docs/content/4.api/config.md
+++ b/docs/content/4.api/config.md
@@ -64,11 +64,11 @@ The canonical site URL. On supported CI platforms (Vercel, [Netlify](https://net
 
 ## `env: string`{lang="ts"}
 
-- Default: `process.env.NODE_ENV`{lang="ts"}
+- Default: `import.meta.envName`{lang="ts"}, then `process.env.NODE_ENV`{lang="ts"}
 
 The environment the site is running in.
 
-See [this issue](https://github.com/nuxt/nuxt/issues/19819) on why we can't use `process.env.NODE_ENV`.
+`NUXT_SITE_ENV` takes priority over this default when configured.
 
 ## `name: string`{lang="ts"}
 
@@ -76,7 +76,7 @@ The name of the site. On [Vercel](https://vercel.com) and Netlify, this is autom
 
 ## `indexable: boolean`{lang="ts"}
 
-- Default: `siteConfig.env === 'production'`{lang="ts"} (where `env` defaults to `process.env.NODE_ENV`)
+- Default: `siteConfig.env === 'production'`{lang="ts"}
 
 Whether the site can be indexed by search engines.
 

--- a/packages/kit/src/init.ts
+++ b/packages/kit/src/init.ts
@@ -17,7 +17,7 @@ export async function initSiteConfig(nuxt: Nuxt | null = tryUseNuxt()): Promise<
   siteConfig.push({
     _context: 'system',
     _priority: SiteConfigPriority.system,
-    env: process.env.NODE_ENV,
+    env: nuxt.options.envName || process.env.NODE_ENV,
   })
 
   // add the env vars lowest priority

--- a/test/unit/init.test.ts
+++ b/test/unit/init.test.ts
@@ -1,0 +1,47 @@
+import type { Nuxt } from '@nuxt/schema'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { initSiteConfig } from '../../packages/kit/src/init'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('initSiteConfig', () => {
+  it('uses the Nuxt environment name before NODE_ENV', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const nuxt = {
+      options: {
+        envName: 'staging',
+      },
+    } as Nuxt
+
+    const siteConfig = await initSiteConfig(nuxt)
+
+    expect(siteConfig?.get().env).toBe('staging')
+  })
+
+  it('uses NUXT_SITE_ENV before the Nuxt environment name', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('NUXT_SITE_ENV', 'preview')
+    const nuxt = {
+      options: {
+        envName: 'staging',
+      },
+    } as Nuxt
+
+    const siteConfig = await initSiteConfig(nuxt)
+
+    expect(siteConfig?.get().env).toBe('preview')
+  })
+
+  it('falls back to NODE_ENV without a Nuxt environment name', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const nuxt = {
+      options: {},
+    } as Nuxt
+
+    const siteConfig = await initSiteConfig(nuxt)
+
+    expect(siteConfig?.get().env).toBe('production')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #105

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Use Nuxt's resolved `envName` for `site.env` when `NUXT_SITE_ENV` is unset, before falling back to `NODE_ENV`. This carries custom values from `nuxt --envName` into site config while explicit site environment variables stay highest priority.