### PR TITLE
perf: don't pull `vue` into the server runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "nuxt-i18n-micro": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
+    "vue": "catalog:",
     "vue-tsc": "catalog:"
   }
 }

--- a/packages/module/src/runtime/server/plugins/injectState.ts
+++ b/packages/module/src/runtime/server/plugins/injectState.ts
@@ -1,5 +1,5 @@
 import devalue from '@nuxt/devalue'
-import { toValue } from 'vue'
+import { toValue } from 'site-config-stack'
 // @ts-expect-error virtual Nitro module
 import { NUXT_SITE_CONFIG_NO_SSR } from '#nuxt-site-config/no-ssr.mjs'
 import { defineNitroPlugin } from '#nuxtseo/nitro'

--- a/packages/site-config/src/index.ts
+++ b/packages/site-config/src/index.ts
@@ -1,4 +1,4 @@
 export * from './priority'
 export * from './stack'
 export * from './type'
-export { envSiteConfig } from './utils'
+export { envSiteConfig, toValue } from './utils'

--- a/packages/site-config/src/stack.ts
+++ b/packages/site-config/src/stack.ts
@@ -1,6 +1,6 @@
 import type { GetSiteConfigOptions, SiteConfigInput, SiteConfigResolved, SiteConfigStack } from './type'
 import { getQuery, hasProtocol, parseHost, parseURL, withHttps } from 'ufo'
-import { toValue } from 'vue'
+import { toValue } from './utils'
 
 export function normalizeSiteConfig(config: SiteConfigResolved): SiteConfigResolved {
   // fix booleans index / trailingSlash

--- a/packages/site-config/src/utils.ts
+++ b/packages/site-config/src/utils.ts
@@ -1,3 +1,32 @@
+/**
+ * `toValue` without importing `vue`.
+ *
+ * Site config values are refs, computeds, getters or plain values, so resolving
+ * one needs `toValue` — but importing it from `vue` costs the whole framework.
+ * `vue` re-exports it from `@vue/runtime-dom`, so a single named import pulls
+ * `@vue/runtime-dom` + `@vue/runtime-core` (~246 KB) into whatever graph asks
+ * for it. On the server that graph is a Nitro plugin, which on a Cloudflare
+ * Worker is evaluated at cold start, before the isolate can answer any request:
+ * the renderer, the scheduler and the component system all initialise so that
+ * one pure function can unwrap a value.
+ *
+ * `@vue/reactivity` is where `toValue` actually lives and is a tenth the size,
+ * but `vue` reaches it through `@vue/runtime-dom` rather than depending on it
+ * directly, so importing it here would make every consumer install a peer.
+ * Nine lines is a better trade than that.
+ *
+ * `__v_isRef` is the same marker Vue's own `isRef` reads, and it is how every
+ * other library in the ecosystem (VueUse's `unref`, for one) recognises a ref
+ * without a hard dependency on Vue.
+ */
+export function toValue<T>(source: T | (() => T) | { __v_isRef?: true, value: T }): T {
+  if (typeof source === 'function')
+    return (source as () => T)()
+  if (source && (source as { __v_isRef?: true }).__v_isRef === true)
+    return (source as { value: T }).value
+  return source as T
+}
+
 const NUXT_SITE_PREFIX = 'NUXT_SITE_'
 const NUXT_PUBLIC_SITE_PREFIX = 'NUXT_PUBLIC_SITE_'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.2.0)(happy-dom@20.11.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      vue:
+        specifier: ^3.5.41
+        version: 3.5.41(typescript@6.0.3)
       vue-tsc:
         specifier: 'catalog:'
         version: 3.3.9(typescript@6.0.3)
@@ -3446,14 +3449,8 @@ packages:
     peerDependencies:
       vue: ^3.5.41
 
-  '@vue/devtools-kit@8.1.5':
-    resolution: {integrity: sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==}
-
   '@vue/devtools-kit@8.2.1':
     resolution: {integrity: sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==}
-
-  '@vue/devtools-shared@8.1.5':
-    resolution: {integrity: sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==}
 
   '@vue/devtools-shared@8.2.1':
     resolution: {integrity: sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==}
@@ -8846,7 +8843,7 @@ snapshots:
       nostics: 1.2.0
       pathe: 2.0.3
       perfect-debounce: 2.1.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       zigpty: 0.2.1
     optional: true
 
@@ -9471,7 +9468,7 @@ snapshots:
 
   '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.4.5)(@vue/compiler-dom@3.5.41)(vue-i18n@11.4.8(vue@3.5.41(typescript@6.0.3)))(vue@3.5.41(typescript@6.0.3))':
     dependencies:
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
     optionalDependencies:
       '@intlify/shared': 11.4.5
       '@vue/compiler-dom': 3.5.41
@@ -9615,7 +9612,7 @@ snapshots:
       srvx: 0.11.22
       std-env: 4.2.0
       tinyclip: 0.1.15
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       ufo: 1.6.4
       youch: 4.1.1
     optionalDependencies:
@@ -9653,7 +9650,7 @@ snapshots:
       srvx: 0.11.22
       std-env: 4.2.0
       tinyclip: 0.1.15
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       ufo: 1.6.4
       youch: 4.1.1
     optionalDependencies:
@@ -12212,7 +12209,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.40':
     dependencies:
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@vue/shared': 3.5.40
       entities: 7.0.1
       estree-walker: 2.0.2
@@ -12274,7 +12271,7 @@ snapshots:
 
   '@vue/devtools-api@8.1.5':
     dependencies:
-      '@vue/devtools-kit': 8.1.5
+      '@vue/devtools-kit': 8.2.1
 
   '@vue/devtools-core@8.2.1(vue@3.5.41(typescript@6.0.3))':
     dependencies:
@@ -12282,21 +12279,12 @@ snapshots:
       '@vue/devtools-shared': 8.2.1
       vue: 3.5.41(typescript@6.0.3)
 
-  '@vue/devtools-kit@8.1.5':
-    dependencies:
-      '@vue/devtools-shared': 8.1.5
-      birpc: 2.9.0
-      hookable: 5.5.3
-      perfect-debounce: 2.1.0
-
   '@vue/devtools-kit@8.2.1':
     dependencies:
       '@vue/devtools-shared': 8.2.1
       birpc: 2.9.0
       hookable: 5.5.3
       perfect-debounce: 2.1.0
-
-  '@vue/devtools-shared@8.1.5': {}
 
   '@vue/devtools-shared@8.2.1': {}
 
@@ -16119,7 +16107,7 @@ snapshots:
     dependencies:
       citty: 0.2.2
       pathe: 2.0.3
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
 
   object-assign@4.1.1: {}
 

--- a/test/unit/to-value.test.ts
+++ b/test/unit/to-value.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { computed, ref, shallowRef } from 'vue'
+import { createSiteConfigStack } from '../../packages/site-config/src/stack'
+import { toValue } from '../../packages/site-config/src/utils'
+
+// `toValue` is reimplemented in `site-config-stack` so the server runtime never
+// imports `vue` (see the comment on the function). That reimplementation reads
+// `__v_isRef` directly, so these cases run against real Vue refs: if Vue ever
+// stops marking refs that way, this goes red rather than silently resolving
+// every ref to the ref object.
+describe('toValue', () => {
+  it('unwraps a ref', () => {
+    expect(toValue(ref('https://example.com'))).toBe('https://example.com')
+  })
+
+  it('unwraps a shallowRef', () => {
+    expect(toValue(shallowRef({ name: 'Example' }))).toEqual({ name: 'Example' })
+  })
+
+  it('unwraps a computed', () => {
+    const name = ref('Example')
+    const upper = computed(() => name.value.toUpperCase())
+    expect(toValue(upper)).toBe('EXAMPLE')
+    name.value = 'Other'
+    expect(toValue(upper)).toBe('OTHER')
+  })
+
+  it('calls a getter', () => {
+    expect(toValue(() => 'https://example.com')).toBe('https://example.com')
+  })
+
+  it('passes plain values through', () => {
+    expect(toValue('https://example.com')).toBe('https://example.com')
+    expect(toValue(0)).toBe(0)
+    expect(toValue(false)).toBe(false)
+    expect(toValue(null)).toBe(null)
+    expect(toValue(undefined)).toBe(undefined)
+  })
+
+  it('leaves a plain object with a value key alone', () => {
+    expect(toValue({ value: 'not a ref' })).toEqual({ value: 'not a ref' })
+  })
+})
+
+describe('site config stack resolves refs', () => {
+  it('resolveRefs unwraps ref and computed entries', () => {
+    const stack = createSiteConfigStack()
+    const name = ref('Example')
+    stack.push({ url: 'https://example.com', name, description: computed(() => `${name.value} site`) })
+    expect(stack.get({ resolveRefs: true })).toMatchObject({
+      url: 'https://example.com',
+      name: 'Example',
+      description: 'Example site',
+    })
+  })
+
+  it('leaves refs intact without resolveRefs', () => {
+    const stack = createSiteConfigStack()
+    stack.push({ name: ref('Example') })
+    expect(stack.get().name).toHaveProperty('value', 'Example')
+  })
+})


### PR DESCRIPTION
### Description

I was cutting Cloudflare Worker cold-start CPU on a Nuxt app and found `@vue/runtime-dom` + `@vue/runtime-core`, about 246 KB, sitting in the eager `chunks/nitro/nitro.mjs` closure. Traced it back to here:

```
virtual:#nitro-internal-virtual/plugins
  -> nuxt-site-config/dist/runtime/server/plugins/injectState.js
  -> vue/dist/vue.runtime.esm-bundler.js
  -> @vue/runtime-dom -> @vue/runtime-core
```

`injectState.ts` and `site-config-stack`'s `get({ resolveRefs: true })` both did `import { toValue } from 'vue'`. `vue` re-exports `toValue` from `@vue/runtime-dom`, so that one named import brings the framework along. Vue is obviously already in the server build for SSR, but it belongs in the lazily-loaded render entry, not in a Nitro plugin: on a Worker the plugin graph is evaluated at cold start, so an unauthenticated 302 was initialising the renderer, the scheduler and the component system to unwrap a ref.

`@vue/reactivity` is the honest import and is a tenth the size, but `vue` reaches it through `@vue/runtime-dom` rather than depending on it directly, so importing it here would make every consumer install a peer. Went with a nine-line local `toValue` in `site-config-stack` instead, exported so `injectState` can use it too.

On the app I was measuring, the eager chunk went 1,925,647 -> 1,815,656 bytes and Vue moved entirely to `chunks/virtual/entry.mjs`, which is what the component chunks import on the render path.

### Additional context

The bit I would like a second opinion on: the local `toValue` recognises refs by reading `__v_isRef`, which is what Vue's own `isRef` checks and what VueUse's `unref` does, but it is still an internal marker. The tests run it against real `ref`, `shallowRef` and `computed` values so a change to that marker fails loudly rather than silently resolving every ref to the ref object — but if you would rather take the peer dependency on `@vue/reactivity` and keep this in Vue's hands, say so and I will swap it.

Also added `vue` to root devDependencies; the new unit test needs it and it was not resolvable from the workspace root before.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).