### PR TITLE
chore: adopt eslint-plugin-harlanzw base config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,27 +4,14 @@ import harlanzw from 'eslint-plugin-harlanzw'
 export default antfu(
   {
     type: 'lib',
-    ignores: [
-      'CLAUDE.md',
-      '.claude/**',
-      'test/fixtures/**',
-      'playground/**',
-      '.playground/**',
-    ],
-    rules: {
-      'no-use-before-define': 'off',
-      'node/prefer-global/process': 'off',
-      'node/prefer-global/buffer': 'off',
-    },
   },
-  {
-    files: ['**/test/**/*.ts', '**/test/**/*.js'],
-    rules: {
-      'ts/no-unsafe-function-type': 'off',
-      'no-console': 'off',
-    },
-  },
-  ...harlanzw({ link: true, nuxt: true, vue: true }),
+  ...harlanzw({
+    // base covers `playground/`, this repo's dev app is `.playground/`
+    base: { ignores: ['.playground/**'] },
+    link: true,
+    nuxt: true,
+    vue: true,
+  }),
   {
     files: ['**/runtime/server/**/*.ts', '**/runtime/app/**/useNitroOrigin.ts', '**/kit/src/**/*.ts'],
     rules: {
@@ -39,14 +26,6 @@ export default antfu(
     ],
     rules: {
       'harlanzw/vue-require-composable-prefix': 'off',
-    },
-  },
-  {
-    files: ['examples/**/package.json'],
-    rules: {
-      'pnpm/json-enforce-catalog': 'off',
-      'pnpm/json-valid-catalog': 'off',
-      'pnpm/json-prefer-workspace-settings': 'off',
     },
   },
 )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.19.0
-      version: 0.19.0
+      specifier: ^0.19.2
+      version: 0.19.2
     execa:
       specifier: ^10.0.1
       version: 10.0.1
@@ -140,7 +140,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.19.2(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       execa:
         specifier: 'catalog:'
         version: 10.0.1
@@ -4604,8 +4604,8 @@ packages:
     peerDependencies:
       eslint: '>=4.19.1'
 
-  eslint-plugin-harlanzw@0.19.0:
-    resolution: {integrity: sha512-Y/fxnaU7J3P9J45RQnlnRo2WEgCXlP9xZD+qfE9UwIykIi4uHo/TeH5qJMYLN8ghQCqyF5alasxHRlAU6nHh7g==}
+  eslint-plugin-harlanzw@0.19.2:
+    resolution: {integrity: sha512-aXVG5dupBlq2Nn94ffBcxw6iSK7OoFoPriWQW2RlE2FHP8PiQt2hfOU1AxuYk0GqgNMIL9c3cKwdhw1RgyeRcw==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -13558,7 +13558,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-harlanzw@0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.19.2(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.18.1
-      version: 0.18.1
+      specifier: ^0.19.0
+      version: 0.19.0
     execa:
       specifier: ^10.0.1
       version: 10.0.1
@@ -140,7 +140,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       execa:
         specifier: 'catalog:'
         version: 10.0.1
@@ -4604,8 +4604,8 @@ packages:
     peerDependencies:
       eslint: '>=4.19.1'
 
-  eslint-plugin-harlanzw@0.18.1:
-    resolution: {integrity: sha512-w2xMDe3zuGPUDO+8GfGUrvUg447XJHqRi6U+IuH/HgsADRqo8SmC4GsQuxKaXq7YdkLe8eYjTtrGYDt/YwnpHw==}
+  eslint-plugin-harlanzw@0.19.0:
+    resolution: {integrity: sha512-Y/fxnaU7J3P9J45RQnlnRo2WEgCXlP9xZD+qfE9UwIykIi4uHo/TeH5qJMYLN8ghQCqyF5alasxHRlAU6nHh7g==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -13558,7 +13558,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-harlanzw@0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.17.1
-      version: 0.17.1
+      specifier: ^0.18.1
+      version: 0.18.1
     execa:
       specifier: ^10.0.1
       version: 10.0.1
@@ -140,7 +140,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       execa:
         specifier: 'catalog:'
         version: 10.0.1
@@ -4604,8 +4604,8 @@ packages:
     peerDependencies:
       eslint: '>=4.19.1'
 
-  eslint-plugin-harlanzw@0.17.1:
-    resolution: {integrity: sha512-JTqWyTYDdMGvo5RDQ1ugq8Y2hGhcSL432WZX3ls52Ie5e+L2MncacI5OrArWB6/8pO7pK3qdm+hgiaFVXmmHxw==}
+  eslint-plugin-harlanzw@0.18.1:
+    resolution: {integrity: sha512-w2xMDe3zuGPUDO+8GfGUrvUg447XJHqRi6U+IuH/HgsADRqo8SmC4GsQuxKaXq7YdkLe8eYjTtrGYDt/YwnpHw==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -13558,7 +13558,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-harlanzw@0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 minimumReleaseAgeExclude:
-  - eslint-plugin-harlanzw@0.18.1
+  - eslint-plugin-harlanzw@0.19.0
   - nuxtseo-layer-devtools
   - nuxtseo-shared
   - '@types/node@25.9.3'
@@ -48,7 +48,7 @@ catalog:
   consola: ^3.4.2
   defu: ^6.1.7
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.18.1
+  eslint-plugin-harlanzw: ^0.19.0
   execa: ^10.0.1
   h3: ^1.15.11
   happy-dom: ^20.11.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 minimumReleaseAgeExclude:
+  - eslint-plugin-harlanzw@0.18.1
   - nuxtseo-layer-devtools
   - nuxtseo-shared
   - '@types/node@25.9.3'
@@ -47,7 +48,7 @@ catalog:
   consola: ^3.4.2
   defu: ^6.1.7
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.17.1
+  eslint-plugin-harlanzw: ^0.18.1
   execa: ^10.0.1
   h3: ^1.15.11
   happy-dom: ^20.11.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 minimumReleaseAgeExclude:
-  - eslint-plugin-harlanzw@0.19.0
+  - eslint-plugin-harlanzw@0.19.2
   - nuxtseo-layer-devtools
   - nuxtseo-shared
   - '@types/node@25.9.3'
@@ -48,7 +48,7 @@ catalog:
   consola: ^3.4.2
   defu: ^6.1.7
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.19.0
+  eslint-plugin-harlanzw: ^0.19.2
   execa: ^10.0.1
   h3: ^1.15.11
   happy-dom: ^20.11.2


### PR DESCRIPTION
### Description

Last of the family, after harlan-zw/nuxt-seo#619, harlan-zw/nuxt-schema-org#150 and harlan-zw/nuxt-seo-utils#136. The override blocks in `eslint.config.mjs` were copy-pasted everywhere; `eslint-plugin-harlanzw` 0.19.2 ships them as `base()`. 52 lines to 31.

```js
export default antfu(
  { type: 'lib' },
  ...harlanzw({
    base: { ignores: ['.playground/**'] },
    link: true,
    nuxt: true,
    vue: true,
  }),
  { files: [/* runtime server, kit */], rules: { 'harlanzw/vue-no-faux-composables': 'off' } },
  { files: [/* getNitroOrigin, utils, getSiteConfig */], rules: { 'harlanzw/vue-require-composable-prefix': 'off' } },
)
```

Gone into base: the `CLAUDE.md` / `.claude` / `test/fixtures` / `playground` ignores, the `no-use-before-define` and node-globals disables, the `**/test/**` relaxation, and the `examples/**/package.json` pnpm catalog block. The two path-scoped `harlanzw/vue-*` disables stay inline, they are genuinely specific to how this repo shapes its runtime utils.

`.playground/**` stays as an explicit ignore. Base ignores `**/playground/**`, and the leading dot means that glob misses this repo's dev app.

Diffed `eslint --print-config` for `packages/module/src/module.ts`, `test/kit.test.ts`, and `examples/basic/package.json`. Two rules changed, both deliberate base normalisations: `ts/no-use-before-define` to off (matching the base-rule version that was already disabled here) and `ts/explicit-function-return-type` to off via `type: 'lib'`. Linted file set identical, 139 files, zero findings before and after.

### Additional context

No orphaned `eslint-disable` comments to clean up, this repo had none for the rules base turns off. `harlanzw/prefer-satisfies` and `harlanzw/nuxt-no-redundant-component-imports`, both new in 0.18.x, report nothing here.

This repo has no `CLAUDE.md` or `.claude`, so the 0.19.2 change that lets prompt rules see agent files is a no-op. Default `agentFiles` handling left alone.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).



